### PR TITLE
Automatic permission updates

### DIFF
--- a/src/admin/admin/admin.controller.spec.ts
+++ b/src/admin/admin/admin.controller.spec.ts
@@ -1,28 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AdminController } from './admin.controller';
-import { RulesService } from '../../permissions/rules/rules.service';
 import { of } from 'rxjs';
 import { CouchdbService } from '../../couchdb/couchdb.service';
 import { authGuardMockProviders } from '../../auth/auth-guard-mock.providers';
 
 describe('AdminController', () => {
   let controller: AdminController;
-  let mockRulesService: RulesService;
   let mockCouchDBService: CouchdbService;
 
   beforeEach(async () => {
     mockCouchDBService = {
-      post: () => of({}),
       get: () => of({}),
       delete: () => of({}),
     } as any;
-    mockRulesService = { loadRules: () => undefined } as any;
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AdminController],
       providers: [
         ...authGuardMockProviders,
         { provide: CouchdbService, useValue: mockCouchDBService },
-        { provide: RulesService, useValue: mockRulesService },
       ],
     }).compile();
 
@@ -31,14 +26,6 @@ describe('AdminController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
-  });
-
-  it('should trigger a reload of the rules', () => {
-    jest.spyOn(mockRulesService, 'loadRules');
-
-    controller.reloadRules('database');
-
-    expect(mockRulesService.loadRules).toHaveBeenCalledWith('database');
   });
 
   it('should delete all docs in the _local db', async () => {

--- a/src/admin/admin/admin.controller.ts
+++ b/src/admin/admin/admin.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Param, Post, UseGuards } from '@nestjs/common';
 import { RulesConfig } from '../../permissions/rules/permission';
 import { RulesService } from '../../permissions/rules/rules.service';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, Observable } from 'rxjs';
 import { AllDocsResponse } from '../../restricted-endpoints/replication/replication-endpoints/couchdb-dtos/all-docs.dto';
 import { CouchdbService } from '../../couchdb/couchdb.service';
 import { CombinedAuthGuard } from '../../auth/guards/combined-auth/combined-auth.guard';
@@ -25,7 +25,7 @@ export class AdminController {
    * @param db name of database from which the rules should be fetched
    */
   @Post('/reload/:db')
-  reloadRules(@Param('db') db: string): Promise<RulesConfig> {
+  reloadRules(@Param('db') db: string): Observable<RulesConfig> {
     return this.rulesService.loadRules(db);
   }
 

--- a/src/admin/admin/admin.controller.ts
+++ b/src/admin/admin/admin.controller.ts
@@ -1,7 +1,5 @@
 import { Controller, Param, Post, UseGuards } from '@nestjs/common';
-import { RulesConfig } from '../../permissions/rules/permission';
-import { RulesService } from '../../permissions/rules/rules.service';
-import { firstValueFrom, Observable } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { AllDocsResponse } from '../../restricted-endpoints/replication/replication-endpoints/couchdb-dtos/all-docs.dto';
 import { CouchdbService } from '../../couchdb/couchdb.service';
 import { CombinedAuthGuard } from '../../auth/guards/combined-auth/combined-auth.guard';
@@ -14,20 +12,7 @@ import { OnlyAuthenticated } from '../../auth/only-authenticated.decorator';
 @UseGuards(CombinedAuthGuard)
 @Controller('admin')
 export class AdminController {
-  constructor(
-    private rulesService: RulesService,
-    private couchdbService: CouchdbService,
-  ) {}
-
-  /**
-   * Reload the rules object from the database to apply changed permissions.
-   *
-   * @param db name of database from which the rules should be fetched
-   */
-  @Post('/reload/:db')
-  reloadRules(@Param('db') db: string): Observable<RulesConfig> {
-    return this.rulesService.loadRules(db);
-  }
+  constructor(private couchdbService: CouchdbService) {}
 
   /**
    * Deletes all local documents of the remote database.

--- a/src/restricted-endpoints/replication/replication-endpoints/couchdb-dtos/bulk-docs.dto.ts
+++ b/src/restricted-endpoints/replication/replication-endpoints/couchdb-dtos/bulk-docs.dto.ts
@@ -6,7 +6,7 @@ export class BulkDocsRequest {
 export class DatabaseDocument {
   // This can be optional when a single document is put into the database
   _id?: string;
-  // This can be optional when a object is created
+  // This can be optional when a document is created
   _rev?: string;
   _deleted?: boolean;
   _revisions?: {

--- a/src/restricted-endpoints/replication/replication-endpoints/couchdb-dtos/changes.dto.ts
+++ b/src/restricted-endpoints/replication/replication-endpoints/couchdb-dtos/changes.dto.ts
@@ -1,0 +1,6 @@
+import { DatabaseDocument } from './bulk-docs.dto';
+
+export interface ChangesResponse {
+  last_seq: string;
+  results: { doc: DatabaseDocument }[];
+}


### PR DESCRIPTION
See #55 

This addition uses the `_changes` feed to automatically receive updates of the permission object in the backend. This should reduce the risk of forgetting to use the `admin/reload` endpoint after updating the permission object.