### PR TITLE
Changes filter

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,9 @@ import { SeverityLevel } from '@sentry/types';
 import { RestrictedEndpointsModule } from './restricted-endpoints/restricted-endpoints.module';
 import { AuthModule } from './auth/auth.module';
 import { CouchdbModule } from './couchdb/couchdb.module';
-import * as Sentry from '@sentry/node';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AdminModule } from './admin/admin.module';
+import { setUser } from '@sentry/node';
 
 const lowSeverityLevels: SeverityLevel[] = ['log', 'info'];
 
@@ -58,7 +58,7 @@ export class AppModule implements NestModule {
     consumer
       .apply((req, res, next) => {
         // reset user before processing a request
-        Sentry.setUser({ username: 'unknown' });
+        setUser({ username: 'unknown' });
         next();
       })
       .forRoutes('*');

--- a/src/auth/guards/basic-auth/basic-auth.strategy.ts
+++ b/src/auth/guards/basic-auth/basic-auth.strategy.ts
@@ -4,7 +4,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { UserInfo } from '../../../restricted-endpoints/session/user-auth.dto';
 import { firstValueFrom } from 'rxjs';
 import { CouchdbService } from '../../../couchdb/couchdb.service';
-import * as Sentry from '@sentry/node';
+import { setUser } from '@sentry/node';
 
 /**
  * Authenticate a user from the BasicAuth header of a request.
@@ -19,7 +19,7 @@ export class BasicAuthStrategy extends PassportStrategy(Strategy) {
     const user = await firstValueFrom(
       this.couchdbService.login(username, password),
     );
-    Sentry.setUser({ username: user.name });
+    setUser({ username: user.name });
     return user;
   }
 }

--- a/src/auth/guards/body-auth/body-auth.strategy.ts
+++ b/src/auth/guards/body-auth/body-auth.strategy.ts
@@ -4,7 +4,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 import { firstValueFrom } from 'rxjs';
 import { CouchdbService } from '../../../couchdb/couchdb.service';
-import * as Sentry from '@sentry/node';
+import { setUser } from '@sentry/node';
 
 /**
  * Authenticate a user from credentials in the body payload of a request.
@@ -21,7 +21,7 @@ export class BodyAuthStrategy extends PassportStrategy(Strategy) {
     const user = await firstValueFrom(
       this.couchdbService.login(username, password),
     );
-    Sentry.setUser({ username: user.name });
+    setUser({ username: user.name });
     return user;
   }
 }

--- a/src/auth/guards/combined-auth/combined-auth.guard.ts
+++ b/src/auth/guards/combined-auth/combined-auth.guard.ts
@@ -7,9 +7,9 @@ import {
 import { BasicAuthGuard } from '../basic-auth/basic-auth.guard';
 import { JwtBearerGuard } from '../jwt-bearer/jwt-bearer.guard';
 import { JwtCookieGuard } from '../jwt-cookie/jwt-cookie.guard';
-import * as Sentry from '@sentry/node';
 import { ONLY_AUTHENTICATED_KEY } from '../../only-authenticated.decorator';
 import { Reflector } from '@nestjs/core';
+import { setUser } from '@sentry/node';
 
 /**
  * This can be used as middleware or guard.
@@ -51,7 +51,7 @@ export class CombinedAuthGuard implements CanActivate, NestMiddleware {
     const req = context.switchToHttp().getRequest();
     return this.authenticateViaGuards(context)
       .then((res) => {
-        Sentry.setUser({ username: req.user.name });
+        setUser({ username: req.user.name });
         return res;
       })
       .catch((err) => {
@@ -79,7 +79,7 @@ export class CombinedAuthGuard implements CanActivate, NestMiddleware {
       }),
     } as ExecutionContext;
     return this.authenticateViaGuards(context)
-      .then(() => Sentry.setUser({ username: req.user.name }))
+      .then(() => setUser({ username: req.user.name }))
       .then(() => next());
   }
 

--- a/src/couchdb/couchdb.service.ts
+++ b/src/couchdb/couchdb.service.ts
@@ -52,7 +52,7 @@ export class CouchdbService {
   private initMapAxiosErrorsToNestjsExceptions() {
     this.httpService.axiosRef.interceptors.response.use(undefined, (err) => {
       if (!err.response) {
-        throw new HttpException('unknown', 400);
+        throw err;
       } else {
         throw new HttpException(err.response.data, err.response.status);
       }

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -33,6 +33,7 @@ describe('RulesService', () => {
       results: [
         { doc: testPermission, seq: '', changes: [], id: testPermission._id },
       ],
+      pending: 0,
     };
     mockCouchDBService = {
       get: () => undefined,
@@ -84,6 +85,7 @@ describe('RulesService', () => {
     const newResponse: ChangesResponse = {
       last_seq: 'new_seq',
       results: [{ ...changesResponse.results[0], doc: newPermissions }],
+      pending: 0,
     };
 
     jest

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -30,7 +30,9 @@ describe('RulesService', () => {
     adminRules = testPermission.data[adminUser.roles[1]];
     changesResponse = {
       last_seq: 'initial_seq',
-      results: [{ doc: testPermission }],
+      results: [
+        { doc: testPermission, seq: '', changes: [], id: testPermission._id },
+      ],
     };
     mockCouchDBService = {
       get: () => undefined,
@@ -81,7 +83,7 @@ describe('RulesService', () => {
     });
     const newResponse: ChangesResponse = {
       last_seq: 'new_seq',
-      results: [{ doc: newPermissions }],
+      results: [{ ...changesResponse.results[0], doc: newPermissions }],
     };
 
     jest

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -4,10 +4,10 @@ import { DocumentAbility } from '../permission/permission.service';
 import { UserInfo } from '../../restricted-endpoints/session/user-auth.dto';
 import { Permission, RulesConfig } from './permission';
 import { catchError, concatMap, defer, of, repeat, retry } from 'rxjs';
-import * as _ from 'lodash';
 import { CouchdbService } from '../../couchdb/couchdb.service';
 import { ConfigService } from '@nestjs/config';
 import { ChangesResponse } from '../../restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto';
+import { get } from 'lodash';
 
 export type DocumentRule = RawRuleOf<DocumentAbility>;
 
@@ -94,7 +94,7 @@ export class RulesService {
       }
 
       const name = rawValue.slice(2, -1);
-      const value = _.get({ user }, name);
+      const value = get({ user }, name);
 
       if (typeof value === 'undefined') {
         throw new ReferenceError(`Variable ${name} is not defined`);

--- a/src/restricted-endpoints/document/document.service.ts
+++ b/src/restricted-endpoints/document/document.service.ts
@@ -10,8 +10,8 @@ import {
   PermissionService,
 } from '../../permissions/permission/permission.service';
 import { permittedFieldsOf } from '@casl/ability/extra';
-import * as _ from 'lodash';
 import { CouchdbService } from '../../couchdb/couchdb.service';
+import { pick } from 'lodash';
 
 /**
  * Read and write individual documents with the remote CouchDB server
@@ -88,7 +88,7 @@ export class DocumentService {
     });
     if (permittedFields.length > 0) {
       // Updating some properties
-      const updatedFields = _.pick(newDoc, permittedFields);
+      const updatedFields = pick(newDoc, permittedFields);
       return Object.assign(oldDoc, updatedFields);
     } else {
       // Updating whole document

--- a/src/restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto.ts
+++ b/src/restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto.ts
@@ -16,5 +16,5 @@ export interface ChangeResult {
 export interface ChangesParams {
   limit: number;
   since: string;
-  include_docs: boolean;
+  include_docs: string;
 }

--- a/src/restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto.ts
+++ b/src/restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto.ts
@@ -3,6 +3,7 @@ import { DatabaseDocument } from './bulk-docs.dto';
 export interface ChangesResponse {
   last_seq: string;
   results: ChangeResult[];
+  pending: number;
 }
 
 export interface ChangeResult {
@@ -10,4 +11,10 @@ export interface ChangeResult {
   changes: { rev: string }[];
   id: string;
   seq: string;
+}
+
+export interface ChangesParams {
+  limit: number;
+  since: string;
+  include_docs: boolean;
 }

--- a/src/restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto.ts
+++ b/src/restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto.ts
@@ -14,7 +14,8 @@ export interface ChangeResult {
 }
 
 export interface ChangesParams {
-  limit: number;
-  since: string;
-  include_docs: string;
+  limit?: number;
+  since?: string;
+  include_docs?: string;
+  [key: string]: any;
 }

--- a/src/restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto.ts
+++ b/src/restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto.ts
@@ -2,5 +2,12 @@ import { DatabaseDocument } from './bulk-docs.dto';
 
 export interface ChangesResponse {
   last_seq: string;
-  results: { doc: DatabaseDocument }[];
+  results: ChangeResult[];
+}
+
+export interface ChangeResult {
+  doc?: DatabaseDocument;
+  changes: { rev: string }[];
+  id: string;
+  seq: string;
 }

--- a/src/restricted-endpoints/replication/changes/changes.controller.spec.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChangesController } from './changes.controller';
+import { CouchdbService } from '../../../couchdb/couchdb.service';
+import { PermissionService } from '../../../permissions/permission/permission.service';
+import { authGuardMockProviders } from '../../../auth/auth-guard-mock.providers';
+import {
+  ChangeResult,
+  ChangesResponse,
+} from '../bulk-document/couchdb-dtos/changes.dto';
+import { DatabaseDocument } from '../bulk-document/couchdb-dtos/bulk-docs.dto';
+import { UserInfo } from '../../session/user-auth.dto';
+import { firstValueFrom, of } from 'rxjs';
+import {
+  DocumentRule,
+  RulesService,
+} from '../../../permissions/rules/rules.service';
+
+describe('ChangesController', () => {
+  let controller: ChangesController;
+  let mockCouchdbService: CouchdbService;
+  let mockRulesService: RulesService;
+  const schoolDoc: DatabaseDocument = { _id: 'School:1' };
+  const privateSchoolDoc: DatabaseDocument = { _id: 'School:2', private: true };
+  const childDoc: DatabaseDocument = { _id: 'Child:1' };
+  const deletedChildDoc: DatabaseDocument = { _id: 'Child:2', _deleted: true };
+  const changes: ChangesResponse = {
+    last_seq: 'some_seq',
+    results: [schoolDoc, privateSchoolDoc, childDoc, deletedChildDoc].map(
+      docToChange,
+    ),
+  };
+  const user: UserInfo = { name: 'username', roles: [] };
+
+  function docToChange(doc: DatabaseDocument): ChangeResult {
+    return {
+      doc,
+      id: doc._id,
+      changes: [{ rev: `rev-${doc._id}` }],
+      seq: `seq-${doc._id}`,
+    };
+  }
+
+  beforeEach(async () => {
+    mockCouchdbService = { get: () => undefined } as any;
+    mockRulesService = { getRulesForUser: () => undefined } as any;
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChangesController],
+      providers: [
+        ...authGuardMockProviders,
+        { provide: CouchdbService, useValue: mockCouchdbService },
+        { provide: RulesService, useValue: mockRulesService },
+        PermissionService,
+      ],
+    }).compile();
+
+    controller = module.get<ChangesController>(ChangesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should use the rules of the requesting user', () => {
+    getChangesResults([]);
+
+    expect(mockRulesService.getRulesForUser).toHaveBeenCalledWith(user);
+  });
+
+  it('should forward params', () => {
+    const params = { since: 'now', feed: 'continuous', limit: '500' };
+    getChangesResults([], params);
+
+    expect(mockCouchdbService.get).toHaveBeenCalledWith('some-db', '_changes', {
+      ...params,
+      include_docs: true,
+    });
+  });
+
+  it('should return all changes if user is allowed to read everything', async () => {
+    const res = await getChangesResults([{ subject: 'all', action: 'manage' }]);
+
+    expect(res.results.map((r) => r.id)).toEqual([
+      schoolDoc._id,
+      privateSchoolDoc._id,
+      childDoc._id,
+      deletedChildDoc._id,
+    ]);
+  });
+
+  it('should filter out changes for which the user does not have access', async () => {
+    const res = await getChangesResults([
+      { subject: 'School', action: 'read', conditions: { private: true } },
+      { subject: 'Child', action: 'manage' },
+    ]);
+
+    expect(res.results.map((r) => r.id)).toEqual([
+      privateSchoolDoc._id,
+      childDoc._id,
+      deletedChildDoc._id,
+    ]);
+  });
+
+  it('should always return deleted docs', async () => {
+    const res = await getChangesResults([
+      { subject: 'School', action: 'read' },
+    ]);
+
+    expect(res.results.map((r) => r.id)).toEqual([
+      schoolDoc._id,
+      privateSchoolDoc._id,
+      deletedChildDoc._id,
+    ]);
+  });
+
+  it('should not return the document content', async () => {
+    const res = await getChangesResults([
+      { subject: 'School', action: 'read' },
+    ]);
+
+    res.results.forEach((r) => expect(r.doc).toBeUndefined());
+  });
+
+  function getChangesResults(rules: DocumentRule[], params?) {
+    jest.spyOn(mockRulesService, 'getRulesForUser').mockReturnValue(rules);
+    jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of({ ...changes }));
+
+    return firstValueFrom(controller.changes('some-db', params, user));
+  }
+});

--- a/src/restricted-endpoints/replication/changes/changes.controller.spec.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.spec.ts
@@ -35,7 +35,7 @@ describe('ChangesController', () => {
   beforeEach(async () => {
     getSpy.mockReset();
     getRulesSpy.mockReset();
-    jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of({ ...changes }));
+    jest.spyOn(mockCouchdbService, 'get').mockReturnValue(changes);
     jest.spyOn(mockRulesService, 'getRulesForUser').mockReturnValue([]);
 
     const module: TestingModule = await Test.createTestingModule({

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -24,7 +24,8 @@ export class ChangesController {
 
   /**
    * Get the changes stream.
-   * The `include_docs` params is automatically set to false.
+   * The changes feed only returns the doc IDs to which the requesting user has access.
+   * Even if `include_docs: true` is set, the stream will not return the document content.
    * @param db
    * @param params
    * @param user
@@ -35,7 +36,6 @@ export class ChangesController {
     @Query() params,
     @User() user: UserInfo,
   ): Observable<ChangesResponse> {
-    // TODO check if longpoll is still working
     return this.couchdbService
       .get<ChangesResponse>(db, '_changes', {
         ...params,

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -47,9 +47,9 @@ export class ChangesController {
         { ...params, since },
         ability,
       );
-      // missing documents till limit
+      // missing changes till limit
       const missing = (params?.limit ?? Infinity) - change.results.length;
-      // overflow documents of this request
+      // overflow changes of this request
       const discarded = Math.max(res.results.length - missing, 0);
       change.results.push(...res.results.slice(0, missing));
       if (change.results.length > 0) {
@@ -61,7 +61,7 @@ export class ChangesController {
         change.pending === 0 ||
         change.results.length >= params.limit
       ) {
-        // enough docs found or none left
+        // enough changes found or none left
         break;
       }
       since = res.last_seq;

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -36,7 +36,7 @@ export class ChangesController {
   async changes(
     @Param('db') db: string,
     @User() user: UserInfo,
-    @Query() params: ChangesParams,
+    @Query() params?: ChangesParams,
   ): Promise<ChangesResponse> {
     const ability = this.permissionService.getAbilityFor(user);
     const change = { results: [] } as ChangesResponse;

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -35,12 +35,12 @@ export class ChangesController {
   @Get(':db/_changes')
   async changes(
     @Param('db') db: string,
-    @Query() params: ChangesParams,
     @User() user: UserInfo,
+    @Query() params: ChangesParams,
   ): Promise<ChangesResponse> {
     const ability = this.permissionService.getAbilityFor(user);
     const change = { results: [] } as ChangesResponse;
-    let since = params.since;
+    let since = params?.since;
     while (true) {
       const res = await this.getPermittedChanges(
         db,
@@ -48,7 +48,7 @@ export class ChangesController {
         ability,
       );
       // missing documents till limit
-      const missing = (params.limit ?? Infinity) - change.results.length;
+      const missing = (params?.limit ?? Infinity) - change.results.length;
       // overflow documents of this request
       const discarded = Math.max(res.results.length - missing, 0);
       change.results.push(...res.results.slice(0, missing));
@@ -57,7 +57,7 @@ export class ChangesController {
       }
       change.pending = res.pending + discarded;
       if (
-        !params.limit ||
+        !params?.limit ||
         change.pending === 0 ||
         change.results.length >= params.limit
       ) {
@@ -66,7 +66,7 @@ export class ChangesController {
       }
       since = res.last_seq;
     }
-    if (params.include_docs !== 'true') {
+    if (params?.include_docs !== 'true') {
       // remove doc content if not requested
       change.results = change.results.map((c) => omit(c, 'doc'));
     }

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -48,7 +48,7 @@ export class ChangesController {
         ability,
       );
       // missing documents till limit
-      const missing = params.limit - change.results.length;
+      const missing = (params.limit ?? Infinity) - change.results.length;
       // overflow documents of this request
       const discarded = Math.max(res.results.length - missing, 0);
       change.results.push(...res.results.slice(0, missing));
@@ -67,7 +67,7 @@ export class ChangesController {
       since = res.last_seq;
     }
     if (params.include_docs !== 'true') {
-      // remove docs if not requested
+      // remove doc content if not requested
       change.results = change.results.map((c) => omit(c, 'doc'));
     }
     return change;

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -1,0 +1,61 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { ChangesResponse } from '../bulk-document/couchdb-dtos/changes.dto';
+import { CouchdbService } from '../../../couchdb/couchdb.service';
+import { map, Observable } from 'rxjs';
+import { OnlyAuthenticated } from '../../../auth/only-authenticated.decorator';
+import { CombinedAuthGuard } from '../../../auth/guards/combined-auth/combined-auth.guard';
+import { User } from '../../../auth/user.decorator';
+import { UserInfo } from '../../session/user-auth.dto';
+import {
+  DocumentAbility,
+  PermissionService,
+} from '../../../permissions/permission/permission.service';
+import { DatabaseDocument } from '../bulk-document/couchdb-dtos/bulk-docs.dto';
+import { omit } from 'lodash';
+
+@OnlyAuthenticated()
+@UseGuards(CombinedAuthGuard)
+@Controller('changes')
+export class ChangesController {
+  constructor(
+    private couchdbService: CouchdbService,
+    private permissionService: PermissionService,
+  ) {}
+
+  /**
+   * Get the changes stream.
+   * The `include_docs` params is automatically set to false.
+   * @param db
+   * @param params
+   * @param user
+   */
+  @Get(':db/_changes')
+  changes(
+    @Param('db') db: string,
+    @Query() params,
+    @User() user: UserInfo,
+  ): Observable<ChangesResponse> {
+    // TODO check if longpoll is still working
+    return this.couchdbService
+      .get<ChangesResponse>(db, '_changes', {
+        ...params,
+        include_docs: true,
+      })
+      .pipe(map((res) => this.filterChanges(res, user)));
+  }
+
+  private filterChanges(
+    changes: ChangesResponse,
+    user: UserInfo,
+  ): ChangesResponse {
+    const ability = this.permissionService.getAbilityFor(user);
+    changes.results = changes.results
+      .filter((change) => this.canReadDoc(change.doc, ability))
+      .map((change) => omit(change, 'doc'));
+    return changes;
+  }
+
+  private canReadDoc(doc: DatabaseDocument, ability: DocumentAbility) {
+    return doc._deleted || ability.can('read', doc);
+  }
+}

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -92,12 +92,14 @@ export class ChangesController {
     changes: ChangesResponse,
     ability: DocumentAbility,
   ): ChangesResponse {
-    changes.results = changes.results.filter(
-      ({ doc }) =>
-        // deleted doc without properties besides _id, _rev and _deleted
-        (doc._deleted && Object.keys(doc).length === 3) ||
-        ability.can('read', doc),
-    );
-    return changes;
+    return {
+      ...changes,
+      results: changes.results.filter(
+        ({ doc }) =>
+          // deleted doc without properties besides _id, _rev and _deleted
+          (doc._deleted && Object.keys(doc).length === 3) ||
+          ability.can('read', doc),
+      ),
+    };
   }
 }

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -93,7 +93,10 @@ export class ChangesController {
     ability: DocumentAbility,
   ): ChangesResponse {
     changes.results = changes.results.filter(
-      ({ doc }) => doc._deleted || ability.can('read', doc),
+      ({ doc }) =>
+        // deleted doc without properties besides _id, _rev and _deleted
+        (doc._deleted && Object.keys(doc).length === 3) ||
+        ability.can('read', doc),
     );
     return changes;
   }

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -15,7 +15,7 @@ import { omit } from 'lodash';
 
 @OnlyAuthenticated()
 @UseGuards(CombinedAuthGuard)
-@Controller('changes')
+@Controller()
 export class ChangesController {
   constructor(
     private couchdbService: CouchdbService,

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -50,12 +50,11 @@ export class ChangesController {
       // missing documents till limit
       const missing = params.limit - change.results.length;
       // overflow documents of this request
-      const discarded = Math.max(change.results.length - missing, 0);
+      const discarded = Math.max(res.results.length - missing, 0);
       change.results.push(...res.results.slice(0, missing));
-      change.last_seq =
-        change.results.length > 0
-          ? change.results[change.results.length - 1].seq
-          : undefined;
+      if (change.results.length > 0) {
+        change.last_seq = change.results[change.results.length - 1].seq;
+      }
       change.pending = res.pending + discarded;
       if (
         !params.limit ||

--- a/src/restricted-endpoints/replication/replication-endpoints/info-endpoints.controller.spec.ts
+++ b/src/restricted-endpoints/replication/replication-endpoints/info-endpoints.controller.spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ReplicationEndpointsController } from './replication-endpoints.controller';
+import { InfoEndpointsController } from './info-endpoints.controller';
 import { of } from 'rxjs';
 import { CouchdbService } from '../../../couchdb/couchdb.service';
 import { authGuardMockProviders } from '../../../auth/auth-guard-mock.providers';
 
-describe('ReplicationEndpointsController', () => {
-  let controller: ReplicationEndpointsController;
+describe('InfoEndpointsController', () => {
+  let controller: InfoEndpointsController;
   let mockCouchDBService: CouchdbService;
 
   beforeEach(async () => {
@@ -16,32 +16,17 @@ describe('ReplicationEndpointsController', () => {
     } as any;
 
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [ReplicationEndpointsController],
+      controllers: [InfoEndpointsController],
       providers: [
         ...authGuardMockProviders,
         { provide: CouchdbService, useValue: mockCouchDBService },
       ],
     }).compile();
 
-    controller = module.get<ReplicationEndpointsController>(
-      ReplicationEndpointsController,
-    );
+    controller = module.get<InfoEndpointsController>(InfoEndpointsController);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
-  });
-
-  it('should overwrite the `include_docs` param in the changes feed', () => {
-    jest.spyOn(mockCouchDBService, 'get');
-
-    controller
-      .changes('someDB', { since: 'now', include_docs: true })
-      .subscribe();
-
-    expect(mockCouchDBService.get).toHaveBeenCalledWith('someDB', '_changes', {
-      since: 'now',
-      include_docs: false,
-    });
   });
 });

--- a/src/restricted-endpoints/replication/replication-endpoints/info-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/replication-endpoints/info-endpoints.controller.ts
@@ -5,7 +5,6 @@ import {
   Param,
   Post,
   Put,
-  Query,
   UseGuards,
 } from '@nestjs/common';
 import { CouchdbService } from '../../../couchdb/couchdb.service';
@@ -22,7 +21,7 @@ import { OnlyAuthenticated } from '../../../auth/only-authenticated.decorator';
 @OnlyAuthenticated()
 @UseGuards(CombinedAuthGuard)
 @Controller()
-export class ReplicationEndpointsController {
+export class InfoEndpointsController {
   constructor(private couchdbService: CouchdbService) {}
 
   /**
@@ -76,19 +75,5 @@ export class ReplicationEndpointsController {
   @Post(':db/_revs_diff')
   revsDiff(@Param('db') db: string, @Body() body) {
     return this.couchdbService.post(db, '_revs_diff', body);
-  }
-
-  /**
-   * Get the changes stream.
-   * The `include_docs` params is automatically set to false.
-   * @param db
-   * @param params
-   */
-  @Get(':db/_changes')
-  changes(@Param('db') db: string, @Query() params) {
-    return this.couchdbService.get(db, '_changes', {
-      ...params,
-      include_docs: false,
-    });
   }
 }

--- a/src/restricted-endpoints/replication/replication.module.ts
+++ b/src/restricted-endpoints/replication/replication.module.ts
@@ -5,10 +5,15 @@ import { BulkDocumentService } from './bulk-document/bulk-document.service';
 import { PermissionModule } from '../../permissions/permission.module';
 import { AuthModule } from '../../auth/auth.module';
 import { BulkDocEndpointsController } from './bulk-document/bulk-doc-endpoints.controller';
+import { ChangesController } from './changes/changes.controller';
 
 @Module({
   imports: [HttpModule, PermissionModule, AuthModule],
-  controllers: [InfoEndpointsController, BulkDocEndpointsController],
+  controllers: [
+    ChangesController,
+    InfoEndpointsController,
+    BulkDocEndpointsController,
+  ],
   providers: [BulkDocumentService],
 })
 export class ReplicationModule {}

--- a/src/restricted-endpoints/replication/replication.module.ts
+++ b/src/restricted-endpoints/replication/replication.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
-import { ReplicationEndpointsController } from './replication-endpoints/replication-endpoints.controller';
+import { InfoEndpointsController } from './replication-endpoints/info-endpoints.controller';
 import { BulkDocumentService } from './bulk-document/bulk-document.service';
 import { PermissionModule } from '../../permissions/permission.module';
 import { AuthModule } from '../../auth/auth.module';
@@ -8,7 +8,7 @@ import { BulkDocEndpointsController } from './bulk-document/bulk-doc-endpoints.c
 
 @Module({
   imports: [HttpModule, PermissionModule, AuthModule],
-  controllers: [ReplicationEndpointsController, BulkDocEndpointsController],
+  controllers: [InfoEndpointsController, BulkDocEndpointsController],
   providers: [BulkDocumentService],
 })
 export class ReplicationModule {}


### PR DESCRIPTION
Closes #108 

By filtering the document on the changes feed, the network traffic for the replication backend is reduced as less documents will be requested by the frontend. This also even hides the doc ids from the frontend.