### PR TITLE
Backend fixes

### DIFF
--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -41,14 +41,24 @@ export class RulesService {
         since: this.lastSeq,
         include_docs: true,
         doc_ids: JSON.stringify([Permission.DOC_ID]),
+        // requests somehow time out after 1 minute
+        timeout: 50000,
       }),
     );
+    const before = new Date().getTime();
 
     return getParams
       .pipe(
-        concatMap((params) =>
-          this.couchdbService.get<ChangesResponse>(db, '_changes', params),
-        ),
+        concatMap((params) => {
+          const date = new Date().getTime();
+          const diff = (date - before) / 1000;
+          console.log(diff.toFixed(2), 'restarting');
+          return this.couchdbService.get<ChangesResponse>(
+            db,
+            '_changes',
+            params,
+          );
+        }),
         catchError((err) => {
           console.error('LOAD RULES ERROR:', err);
           throw err;

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -45,20 +45,12 @@ export class RulesService {
         timeout: 50000,
       }),
     );
-    const before = new Date().getTime();
 
     return getParams
       .pipe(
-        concatMap((params) => {
-          const date = new Date().getTime();
-          const diff = (date - before) / 1000;
-          console.log(diff.toFixed(2), 'restarting');
-          return this.couchdbService.get<ChangesResponse>(
-            db,
-            '_changes',
-            params,
-          );
-        }),
+        concatMap((params) =>
+          this.couchdbService.get<ChangesResponse>(db, '_changes', params),
+        ),
         catchError((err) => {
           console.error('LOAD RULES ERROR:', err);
           throw err;

--- a/src/restricted-endpoints/replication/changes/changes.controller.spec.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.spec.ts
@@ -171,6 +171,20 @@ describe('ChangesController', () => {
     ]);
   });
 
+  it('should return last sequence number if no more matching changes were found', async () => {
+    // Not allowed to read anything
+    getRulesSpy.mockReturnValue([]);
+    getSpy.mockReturnValueOnce(createChanges([schoolDoc, childDoc], 0));
+
+    const lastSeq = docToChange(childDoc).seq;
+
+    const res = await controller.changes('some-db', user, { limit: 3 });
+
+    expect(res.pending).toBe(0);
+    expect(res.last_seq).toBe(lastSeq);
+    expect(res.results).toEqual([]);
+  });
+
   it('should not return docs of deleted documents that still have other properties', async () => {
     const deletedWithoutProps: DatabaseDocument = {
       _id: 'School:deletedWithout',

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -52,8 +52,12 @@ export class ChangesController {
       // overflow changes of this request
       const discarded = Math.max(res.results.length - missing, 0);
       change.results.push(...res.results.slice(0, missing));
-      if (change.results.length > 0) {
+      if (discarded > 0) {
+        // not all requested changes are used
         change.last_seq = change.results[change.results.length - 1].seq;
+      } else {
+        // all changes were used
+        change.last_seq = res.last_seq;
       }
       change.pending = res.pending + discarded;
       if (


### PR DESCRIPTION
On the dev server there is currently an issue where the changes are requested continuously. 
This is because the `last_seq` is not returned correctly from the backend due to a special permissions-data setup.

Also we sometimes see error messages on the backend where the rules object fetch times out (`AxiosError: maxContentLength size of -1 exceeded`.
Normally this is a longpoll and it should be possible to have a open connection for multiple minutes but the axios request times out after one minute. The same happens when using native NodeJS `fetch`. If the same request is send from the command line using curl, everything works fine (I had a exception after around 9 minutes). I did not find a way to change anything the app. I don't think the servers nginx setup is the issue because the requests work fine without the backend.
I now reduced the timeout for CouchDB to 50s so it does not throw errors anymore.