### PR TITLE
fix: fail fast and back off on CouchDB auth errors

### DIFF
--- a/src/couchdb/document-changes.service.spec.ts
+++ b/src/couchdb/document-changes.service.spec.ts
@@ -144,20 +144,18 @@ describe('DocumentChangesService', () => {
   it('should back off and not retry at 1Hz on persistent CouchDB auth errors', () => {
     jest.useFakeTimers();
 
-    const getSpy = jest
-      .spyOn(mockCouchdbService, 'get')
-      .mockReturnValue(
-        throwError(
-          () =>
-            new HttpException(
-              {
-                error: 'unauthorized',
-                reason: 'Name or password is incorrect.',
-              },
-              HttpStatus.UNAUTHORIZED,
-            ),
-        ) as any,
-      );
+    const getSpy = jest.spyOn(mockCouchdbService, 'get').mockReturnValue(
+      throwError(
+        () =>
+          new HttpException(
+            {
+              error: 'unauthorized',
+              reason: 'Name or password is incorrect.',
+            },
+            HttpStatus.UNAUTHORIZED,
+          ),
+      ) as any,
+    );
 
     service.getChanges('app').subscribe({ error: () => undefined });
 

--- a/src/couchdb/document-changes.service.spec.ts
+++ b/src/couchdb/document-changes.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { NEVER, Subject, throwError } from 'rxjs';
 import { CouchdbService } from './couchdb.service';
@@ -136,6 +137,38 @@ describe('DocumentChangesService', () => {
     expect(emitted).toEqual([
       { id: 'User:alice', seq: '2', changes: [{ rev: '2-a' }] },
     ]);
+
+    jest.useRealTimers();
+  });
+
+  it('should back off and not retry at 1Hz on persistent CouchDB auth errors', () => {
+    jest.useFakeTimers();
+
+    const getSpy = jest
+      .spyOn(mockCouchdbService, 'get')
+      .mockReturnValue(
+        throwError(
+          () =>
+            new HttpException(
+              {
+                error: 'unauthorized',
+                reason: 'Name or password is incorrect.',
+              },
+              HttpStatus.UNAUTHORIZED,
+            ),
+        ) as any,
+      );
+
+    service.getChanges('app').subscribe({ error: () => undefined });
+
+    // Initial attempt happens synchronously upon subscription.
+    expect(getSpy).toHaveBeenCalledTimes(1);
+
+    // Without backoff, retry({ delay: 1000 }) would have caused 30 retries in 30s.
+    // With exponential backoff (2s, 4s, 8s, 16s, 32s, 60s cap) we expect well under that.
+    jest.advanceTimersByTime(30_000);
+
+    expect(getSpy.mock.calls.length).toBeLessThan(10);
 
     jest.useRealTimers();
   });

--- a/src/couchdb/document-changes.service.ts
+++ b/src/couchdb/document-changes.service.ts
@@ -126,7 +126,10 @@ export class DocumentChangesService implements OnModuleDestroy {
               concatMap(() => {
                 const isAuth = this.isAuthError(err);
                 const delayMs = isAuth
-                  ? Math.min(60_000, 1000 * 2 ** Math.min(consecutiveAuthFailures, 6))
+                  ? Math.min(
+                      60_000,
+                      1000 * 2 ** Math.min(consecutiveAuthFailures, 6),
+                    )
                   : 1000;
                 return timer(delayMs);
               }),

--- a/src/couchdb/document-changes.service.ts
+++ b/src/couchdb/document-changes.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import {
+  HttpException,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import {
   catchError,
   concatMap,
@@ -9,6 +14,7 @@ import {
   retry,
   Subject,
   Subscription,
+  timer,
 } from 'rxjs';
 import {
   ChangeResult,
@@ -27,6 +33,23 @@ export class DocumentChangesService implements OnModuleDestroy {
   private readonly subscriptions = new Map<string, Subscription>();
 
   constructor(private readonly couchdbService: CouchdbService) {}
+
+  private formatError(err: unknown): string {
+    if (err instanceof HttpException) {
+      const response = err.getResponse();
+      const detail =
+        typeof response === 'string' ? response : JSON.stringify(response);
+      return `HttpException ${err.getStatus()}: ${detail}`;
+    }
+    return (err as Error)?.stack || String(err);
+  }
+
+  private isAuthError(err: unknown): boolean {
+    return (
+      err instanceof HttpException &&
+      (err.getStatus() === 401 || err.getStatus() === 403)
+    );
+  }
 
   onModuleDestroy(): void {
     for (const [db, subscription] of this.subscriptions) {
@@ -55,6 +78,8 @@ export class DocumentChangesService implements OnModuleDestroy {
 
   private startFeed(db: string, subject: Subject<ChangeResult>): void {
     let lastSeq: string = 'now';
+    // Tracks consecutive auth failures so we can back off log spam and request rate.
+    let consecutiveAuthFailures = 0;
 
     const getParams = defer(() =>
       of({
@@ -71,17 +96,47 @@ export class DocumentChangesService implements OnModuleDestroy {
           this.couchdbService.get<ChangesResponse>(db, '_changes', params),
         ),
         catchError((err) => {
-          this.logger.error(
-            `Changes feed error for "${db}":`,
-            err?.stack || String(err),
-          );
+          if (this.isAuthError(err)) {
+            consecutiveAuthFailures += 1;
+            // Log the actionable message loudly once, then once per ~minute, to avoid log flooding.
+            if (
+              consecutiveAuthFailures === 1 ||
+              consecutiveAuthFailures % 60 === 0
+            ) {
+              this.logger.error(
+                `CRITICAL: CouchDB rejected the configured credentials on the changes feed for "${db}" ` +
+                  `(failure #${consecutiveAuthFailures}). Verify DATABASE_USER, DATABASE_PASSWORD and ` +
+                  `DATABASE_URL — the service may be talking to the wrong CouchDB instance. ` +
+                  `Last error: ${this.formatError(err)}`,
+              );
+            }
+          } else {
+            consecutiveAuthFailures = 0;
+            this.logger.error(
+              `Changes feed error for "${db}": ${this.formatError(err)}`,
+            );
+          }
           throw err;
         }),
-        retry({ delay: 1000 }),
+        retry({
+          // Back off aggressively when we keep hitting auth errors so we don't hammer
+          // CouchDB or flood logs at 1Hz; recover immediately on transient errors.
+          delay: (err) =>
+            of(err).pipe(
+              concatMap(() => {
+                const isAuth = this.isAuthError(err);
+                const delayMs = isAuth
+                  ? Math.min(60_000, 1000 * 2 ** Math.min(consecutiveAuthFailures, 6))
+                  : 1000;
+                return timer(delayMs);
+              }),
+            ),
+        }),
         repeat(),
       )
       .subscribe({
         next: (changes) => {
+          consecutiveAuthFailures = 0;
           lastSeq = changes.last_seq;
           for (const result of changes.results ?? []) {
             subject.next(result);
@@ -89,8 +144,7 @@ export class DocumentChangesService implements OnModuleDestroy {
         },
         error: (err) => {
           this.logger.error(
-            `Changes feed for "${db}" terminated unexpectedly:`,
-            err?.stack || String(err),
+            `Changes feed for "${db}" terminated unexpectedly: ${this.formatError(err)}`,
           );
         },
       });

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -285,15 +285,20 @@ describe('RulesService', () => {
 
   it('should fail startup when CouchDB rejects credentials with 401', async () => {
     const unauthorizedCouchdbService = {
-      get: jest.fn().mockReturnValue(
-        throwError(
-          () =>
-            new HttpException(
-              { error: 'unauthorized', reason: 'Name or password is incorrect.' },
-              HttpStatus.UNAUTHORIZED,
-            ),
+      get: jest
+        .fn()
+        .mockReturnValue(
+          throwError(
+            () =>
+              new HttpException(
+                {
+                  error: 'unauthorized',
+                  reason: 'Name or password is incorrect.',
+                },
+                HttpStatus.UNAUTHORIZED,
+              ),
+          ),
         ),
-      ),
     } as any;
     const freshModule = await Test.createTestingModule({
       providers: [

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { of, Subject, throwError } from 'rxjs';
 import { AdminService } from '../../admin/admin.service';
 import { CouchdbService } from '../../couchdb/couchdb.service';
@@ -280,5 +281,45 @@ describe('RulesService', () => {
 
     // Now rules should be available
     expect(freshService.getRulesForUser(normalUser)).toEqual(userRules);
+  });
+
+  it('should fail startup when CouchDB rejects credentials with 401', async () => {
+    const unauthorizedCouchdbService = {
+      get: jest.fn().mockReturnValue(
+        throwError(
+          () =>
+            new HttpException(
+              { error: 'unauthorized', reason: 'Name or password is incorrect.' },
+              HttpStatus.UNAUTHORIZED,
+            ),
+        ),
+      ),
+    } as any;
+    const freshModule = await Test.createTestingModule({
+      providers: [
+        RulesService,
+        {
+          provide: ConfigService,
+          useValue: new ConfigService({
+            [RulesService.ENV_PERMISSION_DB]: DATABASE_NAME,
+          }),
+        },
+        { provide: AdminService, useValue: mockAdminService },
+        { provide: UserIdentityService, useValue: mockUserIdentityService },
+        { provide: CouchdbService, useValue: unauthorizedCouchdbService },
+        {
+          provide: DocumentChangesService,
+          useValue: {
+            getChanges: jest.fn().mockReturnValue(new Subject<ChangeResult>()),
+          },
+        },
+      ],
+    }).compile();
+
+    const freshService = freshModule.get(RulesService);
+
+    await expect(freshService.onModuleInit()).rejects.toBeInstanceOf(
+      HttpException,
+    );
   });
 });

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -1,5 +1,5 @@
 import { RawRuleOf } from '@casl/ability';
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { HttpException, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { get, has } from 'lodash';
 import { firstValueFrom } from 'rxjs';
@@ -52,6 +52,17 @@ export class RulesService implements OnModuleInit {
         this.permission = permissionDoc?.data;
       }
     } catch (error) {
+      if (
+        error instanceof HttpException &&
+        (error.getStatus() === 401 || error.getStatus() === 403)
+      ) {
+        this.logger.error(
+          `CRITICAL: CouchDB rejected the configured credentials when loading initial permissions from "${db}". ` +
+            `Verify DATABASE_USER, DATABASE_PASSWORD and DATABASE_URL match the CouchDB the service is connecting to. ` +
+            `Aborting startup.`,
+        );
+        throw error;
+      }
       this.logger.warn(
         `Failed to load initial permissions from ${db}: ${error instanceof Error ? error.message : String(error)}`,
         error?.stack,

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -1,5 +1,10 @@
 import { RawRuleOf } from '@casl/ability';
-import { HttpException, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import {
+  HttpException,
+  Injectable,
+  Logger,
+  OnModuleInit,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { get, has } from 'lodash';
 import { firstValueFrom } from 'rxjs';


### PR DESCRIPTION
## What & Why

When the service is misconfigured (wrong `DATABASE_URL`, `DATABASE_USER`, or `DATABASE_PASSWORD`), it previously started 'successfully' but served 401 for every request with no actionable log output — making infra issues look like code regressions.

## Changes

### `RulesService` — fail fast on startup auth error
- `loadInitialPermissions` now detects HTTP 401/403 from CouchDB, logs a CRITICAL message naming the env vars to check, and re-throws, aborting Nest startup instead of silently swallowing the error.
- Non-auth errors (network blip, service not ready) still warn and are tolerated — the service falls back to allowing everything and recovers via the live changes feed.

### `DocumentChangesService` — exponential backoff + distinct critical log on auth errors
- Auth errors (401/403) on the `_changes` feed now log a CRITICAL message with remediation hints on the first failure and every ~60 failures (no more 1Hz log flood).
- Retries back off exponentially (2 s → 4 s → 8 s → … → 60 s cap) for auth errors; transient errors keep the existing 1 s retry.
- Success resets the counter.

## Tests
Both behaviours are covered by new unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented exponential backoff for repeated authentication failures to reduce excessive retries.
  * Improved detection and severity-classified logging for credential-rejection events (with throttling to avoid log spam).
  * Services now fail fast with clear errors when authorization is rejected during startup.
  * General error formatting improvements for clearer diagnostics.

* **Tests**
  * Added unit tests covering persistent authentication failures and startup auth rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->