### PR TITLE
fix: parse environment config to relevant types

### DIFF
--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -1,0 +1,91 @@
+import { flatten, parseScalar } from './configuration';
+
+describe('configuration', () => {
+  describe('parseScalar', () => {
+    it('should parse "true" as boolean true', () => {
+      expect(parseScalar('true')).toBe(true);
+    });
+
+    it('should parse "TRUE" as boolean true (case-insensitive)', () => {
+      expect(parseScalar('TRUE')).toBe(true);
+    });
+
+    it('should parse "True" as boolean true (case-insensitive)', () => {
+      expect(parseScalar('True')).toBe(true);
+    });
+
+    it('should parse "false" as boolean false', () => {
+      expect(parseScalar('false')).toBe(false);
+    });
+
+    it('should parse "FALSE" as boolean false (case-insensitive)', () => {
+      expect(parseScalar('FALSE')).toBe(false);
+    });
+
+    it('should parse "False" as boolean false (case-insensitive)', () => {
+      expect(parseScalar('False')).toBe(false);
+    });
+
+    it('should keep numeric strings as strings', () => {
+      expect(parseScalar('8080')).toBe('8080');
+      expect(parseScalar('0')).toBe('0');
+      expect(parseScalar('3.14')).toBe('3.14');
+    });
+
+    it('should keep strings with leading zeros as strings', () => {
+      expect(parseScalar('007')).toBe('007');
+    });
+
+    it('should keep regular strings as strings', () => {
+      expect(parseScalar('hello')).toBe('hello');
+      expect(parseScalar('http://localhost:5984')).toBe('http://localhost:5984');
+    });
+
+    it('should keep empty string as string', () => {
+      expect(parseScalar('')).toBe('');
+    });
+
+    it('should not treat "falsy" or "truthy" as booleans', () => {
+      expect(parseScalar('falsy')).toBe('falsy');
+      expect(parseScalar('truthy')).toBe('truthy');
+    });
+  });
+
+  describe('flatten', () => {
+    it('should flatten nested objects with underscore delimiter', () => {
+      const input = { SENTRY: { ENABLED: true, DSN: 'https://example.com' } };
+      expect(flatten(input)).toEqual({
+        SENTRY_ENABLED: true,
+        SENTRY_DSN: 'https://example.com',
+      });
+    });
+
+    it('should preserve scalar types (booleans, numbers, strings)', () => {
+      const input = { flag: false, count: 42, name: 'test' };
+      expect(flatten(input)).toEqual({
+        flag: false,
+        count: 42,
+        name: 'test',
+      });
+    });
+
+    it('should handle deeply nested objects', () => {
+      const input = { a: { b: { c: 'deep' } } };
+      expect(flatten(input)).toEqual({ a_b_c: 'deep' });
+    });
+
+    it('should skip null values', () => {
+      const input = { a: null, b: 'kept' };
+      expect(flatten(input)).toEqual({ b: 'kept' });
+    });
+
+    it('should stringify arrays as values', () => {
+      const input = { list: ['a', 'b'] };
+      expect(flatten(input)).toEqual({ list: ['a', 'b'] });
+    });
+
+    it('should handle empty objects', () => {
+      expect(flatten({})).toEqual({});
+    });
+  });
+});

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -2,52 +2,29 @@ import { flatten, parseScalar } from './configuration';
 
 describe('configuration', () => {
   describe('parseScalar', () => {
-    it('should parse "true" as boolean true', () => {
+    it('should parse "true"/"false" as booleans', () => {
       expect(parseScalar('true')).toBe(true);
-    });
-
-    it('should parse "TRUE" as boolean true (case-insensitive)', () => {
       expect(parseScalar('TRUE')).toBe(true);
-    });
-
-    it('should parse "True" as boolean true (case-insensitive)', () => {
       expect(parseScalar('True')).toBe(true);
-    });
-
-    it('should parse "false" as boolean false', () => {
       expect(parseScalar('false')).toBe(false);
-    });
-
-    it('should parse "FALSE" as boolean false (case-insensitive)', () => {
       expect(parseScalar('FALSE')).toBe(false);
-    });
-
-    it('should parse "False" as boolean false (case-insensitive)', () => {
       expect(parseScalar('False')).toBe(false);
+
+      expect(parseScalar('falsy')).toBe('falsy');
+      expect(parseScalar('truthy')).toBe('truthy');
     });
 
     it('should keep numeric strings as strings', () => {
       expect(parseScalar('8080')).toBe('8080');
       expect(parseScalar('0')).toBe('0');
       expect(parseScalar('3.14')).toBe('3.14');
-    });
-
-    it('should keep strings with leading zeros as strings', () => {
       expect(parseScalar('007')).toBe('007');
     });
 
     it('should keep regular strings as strings', () => {
       expect(parseScalar('hello')).toBe('hello');
       expect(parseScalar('http://localhost:5984')).toBe('http://localhost:5984');
-    });
-
-    it('should keep empty string as string', () => {
       expect(parseScalar('')).toBe('');
-    });
-
-    it('should not treat "falsy" or "truthy" as booleans', () => {
-      expect(parseScalar('falsy')).toBe('falsy');
-      expect(parseScalar('truthy')).toBe('truthy');
     });
   });
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -12,18 +12,18 @@ const CONFIG_FILENAME = 'app.yaml';
  * Result is provided to the NestJS ConfigService.
  * See: /src/config/app.yaml
  */
-export function AppConfiguration(): Record<string, string> {
+export function AppConfiguration(): Record<string, unknown> {
   const fromYaml = flatten(
     yaml.load(readFileSync(join(__dirname, CONFIG_FILENAME), 'utf8')) as Record<
       string,
-      string
+      unknown
     >,
   );
 
-  const fromEnv: Record<string, string> = {};
+  const fromEnv: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined) {
-      fromEnv[key] = value;
+      fromEnv[key] = parseScalar(value);
     }
   }
 
@@ -34,20 +34,32 @@ export function AppConfiguration(): Record<string, string> {
 /**
  * Recursively create a flat key-value object where keys contain nested keys as prefixes
  */
-function flatten(
+export function flatten(
   obj: Record<string, unknown>,
   prefix = '',
   delimiter = '_',
-): Record<string, string> {
-  return Object.keys(obj).reduce<Record<string, string>>((acc, k) => {
+): Record<string, unknown> {
+  return Object.keys(obj).reduce<Record<string, unknown>>((acc, k) => {
     const pre = prefix.length ? prefix + delimiter : '';
     const value = obj[k];
 
     if (value !== null && !Array.isArray(value) && typeof value === 'object') {
       Object.assign(acc, flatten(value as Record<string, unknown>, pre + k));
     } else if (value != null) {
-      acc[pre + k] = String(value);
+      acc[pre + k] = value;
     }
     return acc;
   }, {});
+}
+
+/**
+ * Parse a string value into its most appropriate scalar type.
+ * Only handles booleans ("true"/"false") to avoid accidental conversion
+ * of numeric strings (ports, IDs, tokens with leading zeros, etc.).
+ */
+export function parseScalar(value: string): unknown {
+  const lower = value.toLowerCase();
+  if (lower === 'true') return true;
+  if (lower === 'false') return false;
+  return value;
 }

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -18,21 +18,11 @@ function loadSentryConfiguration(
   configService: ConfigService,
 ): SentryConfiguration {
   return {
-    ENABLED: parseBoolean(configService.get('SENTRY_ENABLED')),
+    ENABLED: configService.get<boolean>('SENTRY_ENABLED', false),
     DSN: configService.get('SENTRY_DSN', ''),
     INSTANCE_NAME: configService.get('SENTRY_INSTANCE_NAME', ''),
     ENVIRONMENT: configService.get('SENTRY_ENVIRONMENT', ''),
   };
-}
-
-function parseBoolean(value: unknown): boolean {
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    return value.toLowerCase() === 'true';
-  }
-  return false;
 }
 
 /**


### PR DESCRIPTION
closes #234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration values now preserve their original types (booleans, numbers, strings) instead of coercing everything to strings.

* **Bug Fixes**
  * Boolean configuration values are now properly recognized and parsed as booleans.

* **Tests**
  * Added test suite validating configuration parsing and type preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->