### PR TITLE
fix: group _changes slow warnings into single Sentry issue

### DIFF
--- a/src/common/sentry-logger.service.ts
+++ b/src/common/sentry-logger.service.ts
@@ -34,10 +34,24 @@ export class SentryLogger extends ConsoleLogger {
     // it as an exception so Sentry shows the proper stack trace.
     // Otherwise just send the message text.
     const error = [message, ...optionalParams].find((p) => p instanceof Error);
+
+    // Collect any object params (including additional Errors) as structured
+    // metadata so callers can pass a constant message (for stable Sentry
+    // grouping) and still attach per-event details as `extra` data.
+    // Exclude only the Error we hand to `captureException` to avoid
+    // duplicating it.
+    const extras = optionalParams.filter(
+      (p) => p && typeof p === 'object' && p !== error,
+    );
+    const captureContext =
+      extras.length > 0
+        ? { level, extra: { details: extras.length === 1 ? extras[0] : extras } }
+        : { level };
+
     if (error) {
-      Sentry.captureException(error, { level });
+      Sentry.captureException(error, captureContext);
     } else {
-      Sentry.captureMessage(String(message), level);
+      Sentry.captureMessage(String(message), captureContext);
     }
   }
 }

--- a/src/common/sentry-logger.service.ts
+++ b/src/common/sentry-logger.service.ts
@@ -45,7 +45,10 @@ export class SentryLogger extends ConsoleLogger {
     );
     const captureContext =
       extras.length > 0
-        ? { level, extra: { details: extras.length === 1 ? extras[0] : extras } }
+        ? {
+            level,
+            extra: { details: extras.length === 1 ? extras[0] : extras },
+          }
         : { level };
 
     if (error) {

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -136,13 +136,9 @@ export class ChangesController {
       pending: change.pending,
     };
     if (duration > 2000 || iterations > 2) {
-      this.logger.warn(
-        `_changes request slow: ${JSON.stringify(details)}`,
-      );
+      this.logger.warn('_changes request slow', details);
     } else {
-      this.logger.debug(
-        `_changes request completed: ${JSON.stringify(details)}`,
-      );
+      this.logger.debug('_changes request completed', details);
     }
 
     return change;

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -123,15 +123,26 @@ export class ChangesController {
     }
 
     const duration = Date.now() - startTime;
-    const details =
-      `db="${db}" user="${userName}" duration=${duration}ms ` +
-      `iterations=${iterations} fetched=${totalFetched} ` +
-      `permitted=${change.results.length} lost=${change.lostPermissions?.length ?? 0} ` +
-      `since=${params?.since ?? 'undefined'} limit=${params?.limit ?? 'none'} pending=${change.pending}`;
+    const details = {
+      db,
+      user: userName,
+      duration,
+      iterations,
+      fetched: totalFetched,
+      permitted: change.results.length,
+      lost: change.lostPermissions?.length ?? 0,
+      since: params?.since ?? 'undefined',
+      limit: params?.limit ?? 'none',
+      pending: change.pending,
+    };
     if (duration > 2000 || iterations > 2) {
-      this.logger.warn(`_changes request slow: ${details}`);
+      this.logger.warn(
+        `_changes request slow: ${JSON.stringify(details)}`,
+      );
     } else {
-      this.logger.debug(`_changes request completed: ${details}`);
+      this.logger.debug(
+        `_changes request completed: ${JSON.stringify(details)}`,
+      );
     }
 
     return change;

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -115,8 +115,8 @@ function initSentrySdk(sentryConfiguration: SentryConfiguration): void {
         return null;
       }
 
-      // Group console-captured log messages by their static prefix
-      // (before the first colon) so dynamic details don't fragment issues.
+      // Group log messages by their static prefix (before the first colon)
++     // so dynamic details don't fragment issues.
       if (event.message) {
         const prefixEnd = event.message.indexOf(':');
         if (prefixEnd > 0) {

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -117,7 +117,7 @@ function initSentrySdk(sentryConfiguration: SentryConfiguration): void {
 
       // Group console-captured log messages by their static prefix
       // (before the first colon) so dynamic details don't fragment issues.
-      if (event.logger === 'console' && event.message) {
+      if (event.message) {
         const prefixEnd = event.message.indexOf(':');
         if (prefixEnd > 0) {
           event.fingerprint = [event.message.substring(0, prefixEnd)];

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -116,7 +116,7 @@ function initSentrySdk(sentryConfiguration: SentryConfiguration): void {
       }
 
       // Group log messages by their static prefix (before the first colon)
-+     // so dynamic details don't fragment issues.
+      // so dynamic details don't fragment issues.
       if (event.message) {
         const prefixEnd = event.message.indexOf(':');
         if (prefixEnd > 0) {


### PR DESCRIPTION
Move volatile request parameters (since, user, duration) from the message string into a JSON object so Sentry's fingerprinting can group all slow-changes warnings into a single issue.

Also remove the 'event.logger === console' guard from beforeSend fingerprinting which was preventing the grouping from working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Request logging has been restructured with improved detail organization for better debugging visibility.
  * Error event grouping logic has been updated for more consistent categorization in monitoring systems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aam-Digital/replication-backend/pull/250)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->