### PR TITLE
perf: cache successful basic-auth logins for 60s

### DIFF
--- a/src/auth/guards/basic-auth/basic-auth.strategy.spec.ts
+++ b/src/auth/guards/basic-auth/basic-auth.strategy.spec.ts
@@ -1,0 +1,80 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { of, throwError } from 'rxjs';
+import { CouchdbService } from '../../../couchdb/couchdb.service';
+import { UserInfo } from '../../../restricted-endpoints/session/user-auth.dto';
+import { BasicAuthStrategy } from './basic-auth.strategy';
+
+describe('BasicAuthStrategy', () => {
+  let strategy: BasicAuthStrategy;
+  let mockCouchdbService: CouchdbService;
+  const user = new UserInfo('user-id', 'testUser', ['user_app']);
+
+  beforeEach(async () => {
+    mockCouchdbService = {
+      login: jest.fn().mockReturnValue(of(user)),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BasicAuthStrategy,
+        { provide: CouchdbService, useValue: mockCouchdbService },
+      ],
+    }).compile();
+
+    strategy = module.get(BasicAuthStrategy);
+  });
+
+  it('should log in via CouchDB and return the user', async () => {
+    const result = await strategy.validate('testUser', 'pass');
+
+    expect(result).toBe(user);
+    expect(mockCouchdbService.login).toHaveBeenCalledWith('testUser', 'pass');
+  });
+
+  it('should reuse a cached login within the TTL instead of calling CouchDB again', async () => {
+    await strategy.validate('testUser', 'pass');
+    const second = await strategy.validate('testUser', 'pass');
+
+    expect(second).toBe(user);
+    expect(mockCouchdbService.login).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not serve the cached login for a different password', async () => {
+    await strategy.validate('testUser', 'pass');
+
+    jest
+      .spyOn(mockCouchdbService, 'login')
+      .mockReturnValue(throwError(() => new UnauthorizedException()));
+
+    await expect(strategy.validate('testUser', 'wrong-pass')).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(mockCouchdbService.login).toHaveBeenCalledWith(
+      'testUser',
+      'wrong-pass',
+    );
+  });
+
+  it('should not cache failed logins', async () => {
+    jest
+      .spyOn(mockCouchdbService, 'login')
+      .mockReturnValue(throwError(() => new UnauthorizedException()));
+
+    await expect(strategy.validate('testUser', 'bad')).rejects.toThrow();
+    await expect(strategy.validate('testUser', 'bad')).rejects.toThrow();
+
+    expect(mockCouchdbService.login).toHaveBeenCalledTimes(2);
+  });
+
+  it('should re-validate with CouchDB after the TTL expired', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(0);
+
+    await strategy.validate('testUser', 'pass');
+    nowSpy.mockReturnValue(BasicAuthStrategy.LOGIN_CACHE_TTL_MS + 1);
+    await strategy.validate('testUser', 'pass');
+
+    expect(mockCouchdbService.login).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
+});

--- a/src/auth/guards/basic-auth/basic-auth.strategy.ts
+++ b/src/auth/guards/basic-auth/basic-auth.strategy.ts
@@ -33,9 +33,12 @@ export class BasicAuthStrategy extends PassportStrategy(Strategy) {
   async validate(username: string, password: string): Promise<UserInfo> {
     const key = this.cacheKey(username, password);
     const cached = this.loginCache.get(key);
-    if (cached && cached.expiresAtMs > Date.now()) {
-      setUser({ username: cached.user.name });
-      return cached.user;
+    if (cached) {
+      if (cached.expiresAtMs > Date.now()) {
+        setUser({ username: cached.user.name });
+        return cached.user;
+      }
+      this.loginCache.delete(key); // drop the expired entry
     }
 
     // failed logins throw here and are never cached
@@ -43,10 +46,7 @@ export class BasicAuthStrategy extends PassportStrategy(Strategy) {
       this.couchdbService.login(username, password),
     );
 
-    if (this.loginCache.size >= BasicAuthStrategy.LOGIN_CACHE_MAX_ENTRIES) {
-      // simple wholesale eviction; entries are cheap to rebuild
-      this.loginCache.clear();
-    }
+    this.evictIfNeeded();
     this.loginCache.set(key, {
       user,
       expiresAtMs: Date.now() + BasicAuthStrategy.LOGIN_CACHE_TTL_MS,
@@ -54,6 +54,30 @@ export class BasicAuthStrategy extends PassportStrategy(Strategy) {
 
     setUser({ username: user.name });
     return user;
+  }
+
+  /**
+   * Keep the cache bounded: drop expired entries first, then evict the oldest
+   * live ones (Map preserves insertion order) — so exceeding the cap degrades
+   * the coldest entries instead of wiping every warm one.
+   */
+  private evictIfNeeded(): void {
+    if (this.loginCache.size < BasicAuthStrategy.LOGIN_CACHE_MAX_ENTRIES) {
+      return;
+    }
+    const now = Date.now();
+    for (const [key, entry] of this.loginCache) {
+      if (entry.expiresAtMs <= now) {
+        this.loginCache.delete(key);
+      }
+    }
+    while (this.loginCache.size >= BasicAuthStrategy.LOGIN_CACHE_MAX_ENTRIES) {
+      const oldest = this.loginCache.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.loginCache.delete(oldest);
+    }
   }
 
   /** never store plaintext credentials — key entries on a digest */

--- a/src/auth/guards/basic-auth/basic-auth.strategy.ts
+++ b/src/auth/guards/basic-auth/basic-auth.strategy.ts
@@ -5,21 +5,59 @@ import { UserInfo } from '../../../restricted-endpoints/session/user-auth.dto';
 import { firstValueFrom } from 'rxjs';
 import { CouchdbService } from '../../../couchdb/couchdb.service';
 import { setUser } from '@sentry/node';
+import { createHash } from 'crypto';
 
 /**
  * Authenticate a user from the BasicAuth header of a request.
+ *
+ * Successful logins are cached for a short time so that request bursts
+ * (e.g. during replication) do not trigger a CouchDB `_session` round trip
+ * — and the password hash verification inside CouchDB — for every request.
  */
 @Injectable()
 export class BasicAuthStrategy extends PassportStrategy(Strategy) {
+  /** how long a successful login is reused without re-checking with CouchDB */
+  static readonly LOGIN_CACHE_TTL_MS = 60_000;
+  /** safety cap to bound memory use */
+  static readonly LOGIN_CACHE_MAX_ENTRIES = 1000;
+
+  private readonly loginCache = new Map<
+    string,
+    { user: UserInfo; expiresAtMs: number }
+  >();
+
   constructor(private couchdbService: CouchdbService) {
     super();
   }
 
   async validate(username: string, password: string): Promise<UserInfo> {
+    const key = this.cacheKey(username, password);
+    const cached = this.loginCache.get(key);
+    if (cached && cached.expiresAtMs > Date.now()) {
+      setUser({ username: cached.user.name });
+      return cached.user;
+    }
+
+    // failed logins throw here and are never cached
     const user = await firstValueFrom(
       this.couchdbService.login(username, password),
     );
+
+    if (this.loginCache.size >= BasicAuthStrategy.LOGIN_CACHE_MAX_ENTRIES) {
+      // simple wholesale eviction; entries are cheap to rebuild
+      this.loginCache.clear();
+    }
+    this.loginCache.set(key, {
+      user,
+      expiresAtMs: Date.now() + BasicAuthStrategy.LOGIN_CACHE_TTL_MS,
+    });
+
     setUser({ username: user.name });
     return user;
+  }
+
+  /** never store plaintext credentials — key entries on a digest */
+  private cacheKey(username: string, password: string): string {
+    return createHash('sha256').update(`${username}:${password}`).digest('hex');
   }
 }

--- a/test/session-documents.e2e-spec.ts
+++ b/test/session-documents.e2e-spec.ts
@@ -83,6 +83,35 @@ describe('Session & document endpoints (e2e)', () => {
         .expect(200);
       expect(res.body.userCtx ?? null).toBeNull();
     });
+
+    it('caches basic auth logins instead of hitting CouchDB per request', async () => {
+      ctx.couch.addUser('burst-user', 'burst-pw', ['user_app']);
+      ctx.couch.clearRequestLog();
+
+      for (let i = 0; i < 3; i++) {
+        await request(ctx.app.getHttpServer())
+          .get('/_session')
+          .set(...basicAuth('burst-user', 'burst-pw'))
+          .expect(200);
+      }
+
+      expect(ctx.couch.sessionRequestCount).toBe(1);
+    });
+
+    it('does not authenticate a wrong password after a cached login', async () => {
+      ctx.couch.addUser('cache-victim', 'right-pw', ['user_app']);
+      await request(ctx.app.getHttpServer())
+        .get('/_session')
+        .set(...basicAuth('cache-victim', 'right-pw'))
+        .expect(200);
+
+      const res = await request(ctx.app.getHttpServer())
+        .get('/_session')
+        .set(...basicAuth('cache-victim', 'wrong-pw'))
+        .expect(200);
+      // falls through all auth modes -> anonymous
+      expect(res.body.userCtx ?? null).toBeNull();
+    });
   });
 
   describe('GET /:db/:docId', () => {


### PR DESCRIPTION
## Summary

Part of #261 (item 3). Based on #262 (e2e suite) — merge that first; GitHub retargets automatically. Independent of the other improvement PRs.

`BasicAuthStrategy` called CouchDB `_session` on **every request** — an extra round trip plus a PBKDF2 password verification *inside CouchDB*. Replication bursts (hundreds of `_bulk_get`/`_changes` requests) amplify this into significant CouchDB load.

## Changes

- Successful logins are cached for **60 s**, keyed by `sha256(username:password)` — plaintext credentials are never stored.
- Failed logins are never cached; a wrong password can never match a cached entry because the digest differs (covered by unit + e2e tests).
- 1000-entry cap bounds memory.

## Security notes

- Cache hits return the same `UserInfo` (roles) for up to 60 s; a password change or user deactivation in CouchDB therefore takes effect after at most 60 s for basic-auth traffic. This matches the existing 5-min identity cache tolerance elsewhere in the service.

## Test plan

- unit: `basic-auth.strategy.spec.ts` (cache hit, different password, failed logins not cached, TTL expiry)
- e2e: burst of 3 requests results in exactly 1 upstream `_session` call; wrong password after a cached login stays unauthenticated
- 179 unit / 42 e2e tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Basic Authentication now reuses successful login results for a short period, reducing repeated authentication lookups during request bursts.
  * Cached credentials are validated against the full username and password, preventing incorrect reuse.

* **Bug Fixes**
  * Failed login attempts are not cached.
  * Expired authentication results are revalidated automatically.
  * Authentication cache size is limited to prevent unbounded growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->