### PR TITLE
fix: add request timeout and keep-alive socket cap for CouchDB requests

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,12 @@ DATABASE_USER=admin
 # the database name where the permissions definition document is stored
 PERMISSION_DB=app
 
+# (optional) per-request timeout in ms for requests to CouchDB (default 60000).
+# Must stay above ~55000 because the internal changes feed uses 50s longpoll requests.
+# DATABASE_TIMEOUT_MS=60000
+# (optional) maximum number of parallel keep-alive connections to CouchDB (default 50)
+# DATABASE_MAX_SOCKETS=50
+
 # Keycloak admin API configuration used to resolve users/roles for permission checks
 KEYCLOAK_ADMIN_BASE_URL=https://keycloak.localhost
 KEYCLOAK_ADMIN_CLIENT_ID=aam-backend

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ In both cases the following environment variables should be defined:
 - `DATABASE_URL` the URL where the CouchDB instance can be accessed
 - `DATABASE_USER` the name of a user that is a `member` of all databases inside the CouchDB instance. In case the proxy is also used to create new entries in the `_users` database, then this user needs to be `admin` in this database.
 - `DATABASE_PASSWORD` the password for the `DATABASE_USER`
+- `DATABASE_TIMEOUT_MS` (optional) per-request timeout in milliseconds for requests to CouchDB (default `60000`). Requests that exceed this are aborted instead of hanging forever. Must stay above ~`55000`, because the internal changes feed uses 50s longpoll requests that must not be aborted client-side.
+- `DATABASE_MAX_SOCKETS` (optional) maximum number of parallel keep-alive connections to CouchDB (default `50`). Bounds the connection load that request bursts (e.g. many syncing clients) can place on CouchDB.
 - `PERMISSION_DB` the database name where the permissions definition document is stored
 - `JWT_SECRET` a secret to create JWT tokens. They are used in the JWT auth which works similar to CouchDB's `POST /_session` endpoint. This should be changed to prevent others to create fake JWT tokens.
 - `JWT_PUBLIC_KEY` the public key which can be used to validate a JWT in the authorization header (bearer). The structure is the same as and compatible with [CouchDB JWT auth](https://docs.couchdb.org/en/stable/api/server/authn.html#jwt-authentication).

--- a/src/couchdb/couchdb.module.spec.ts
+++ b/src/couchdb/couchdb.module.spec.ts
@@ -1,0 +1,60 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  couchdbHttpOptions,
+  DATABASE_MAX_SOCKETS_ENV,
+  DATABASE_TIMEOUT_ENV,
+  DEFAULT_DATABASE_MAX_SOCKETS,
+  DEFAULT_DATABASE_TIMEOUT_MS,
+} from './couchdb.module';
+
+/** read the (untyped) constructor options back from an http(s).Agent */
+function agentOptions(agent: unknown): {
+  keepAlive?: boolean;
+  maxSockets?: number;
+} {
+  return (agent as { options: { keepAlive?: boolean; maxSockets?: number } })
+    .options;
+}
+
+describe('couchdbHttpOptions', () => {
+  it('applies a default timeout and keep-alive agents with a socket cap', () => {
+    const options = couchdbHttpOptions(new ConfigService({}));
+
+    expect(options.timeout).toBe(DEFAULT_DATABASE_TIMEOUT_MS);
+    expect(agentOptions(options.httpAgent)).toMatchObject({
+      keepAlive: true,
+      maxSockets: DEFAULT_DATABASE_MAX_SOCKETS,
+    });
+    expect(agentOptions(options.httpsAgent)).toMatchObject({
+      keepAlive: true,
+      maxSockets: DEFAULT_DATABASE_MAX_SOCKETS,
+    });
+  });
+
+  it('allows overriding timeout and socket cap via environment config', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({
+        [DATABASE_TIMEOUT_ENV]: '120000',
+        [DATABASE_MAX_SOCKETS_ENV]: '10',
+      }),
+    );
+
+    expect(options.timeout).toBe(120000);
+    expect(agentOptions(options.httpAgent).maxSockets).toBe(10);
+    expect(agentOptions(options.httpsAgent).maxSockets).toBe(10);
+  });
+
+  it('falls back to defaults for invalid values', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({
+        [DATABASE_TIMEOUT_ENV]: 'not-a-number',
+        [DATABASE_MAX_SOCKETS_ENV]: '',
+      }),
+    );
+
+    expect(options.timeout).toBe(DEFAULT_DATABASE_TIMEOUT_MS);
+    expect(agentOptions(options.httpAgent).maxSockets).toBe(
+      DEFAULT_DATABASE_MAX_SOCKETS,
+    );
+  });
+});

--- a/src/couchdb/couchdb.module.spec.ts
+++ b/src/couchdb/couchdb.module.spec.ts
@@ -5,6 +5,7 @@ import {
   DATABASE_TIMEOUT_ENV,
   DEFAULT_DATABASE_MAX_SOCKETS,
   DEFAULT_DATABASE_TIMEOUT_MS,
+  MIN_DATABASE_TIMEOUT_MS,
 } from './couchdb.module';
 
 /** read the (untyped) constructor options back from an http(s).Agent */
@@ -56,5 +57,13 @@ describe('couchdbHttpOptions', () => {
     expect(agentOptions(options.httpAgent).maxSockets).toBe(
       DEFAULT_DATABASE_MAX_SOCKETS,
     );
+  });
+
+  it('clamps a too-low timeout up to the floor so it cannot abort the longpoll feed', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({ [DATABASE_TIMEOUT_ENV]: '30000' }),
+    );
+
+    expect(options.timeout).toBe(MIN_DATABASE_TIMEOUT_MS);
   });
 });

--- a/src/couchdb/couchdb.module.spec.ts
+++ b/src/couchdb/couchdb.module.spec.ts
@@ -66,4 +66,67 @@ describe('couchdbHttpOptions', () => {
 
     expect(options.timeout).toBe(MIN_DATABASE_TIMEOUT_MS);
   });
+
+  it('rejects negative timeout and falls back to default', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({ [DATABASE_TIMEOUT_ENV]: '-1' }),
+    );
+
+    expect(options.timeout).toBe(DEFAULT_DATABASE_TIMEOUT_MS);
+  });
+
+  it('rejects zero timeout and falls back to default', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({ [DATABASE_TIMEOUT_ENV]: '0' }),
+    );
+
+    expect(options.timeout).toBe(DEFAULT_DATABASE_TIMEOUT_MS);
+  });
+
+  it('rejects Infinity timeout and falls back to default', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({ [DATABASE_TIMEOUT_ENV]: 'Infinity' }),
+    );
+
+    expect(options.timeout).toBe(DEFAULT_DATABASE_TIMEOUT_MS);
+  });
+
+  it('rejects negative maxSockets and falls back to default', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({ [DATABASE_MAX_SOCKETS_ENV]: '-1' }),
+    );
+
+    expect(agentOptions(options.httpAgent).maxSockets).toBe(
+      DEFAULT_DATABASE_MAX_SOCKETS,
+    );
+    expect(agentOptions(options.httpsAgent).maxSockets).toBe(
+      DEFAULT_DATABASE_MAX_SOCKETS,
+    );
+  });
+
+  it('rejects zero maxSockets and falls back to default', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({ [DATABASE_MAX_SOCKETS_ENV]: '0' }),
+    );
+
+    expect(agentOptions(options.httpAgent).maxSockets).toBe(
+      DEFAULT_DATABASE_MAX_SOCKETS,
+    );
+    expect(agentOptions(options.httpsAgent).maxSockets).toBe(
+      DEFAULT_DATABASE_MAX_SOCKETS,
+    );
+  });
+
+  it('rejects Infinity maxSockets and falls back to default', () => {
+    const options = couchdbHttpOptions(
+      new ConfigService({ [DATABASE_MAX_SOCKETS_ENV]: 'Infinity' }),
+    );
+
+    expect(agentOptions(options.httpAgent).maxSockets).toBe(
+      DEFAULT_DATABASE_MAX_SOCKETS,
+    );
+    expect(agentOptions(options.httpsAgent).maxSockets).toBe(
+      DEFAULT_DATABASE_MAX_SOCKETS,
+    );
+  });
 });

--- a/src/couchdb/couchdb.module.ts
+++ b/src/couchdb/couchdb.module.ts
@@ -1,5 +1,5 @@
 import { HttpModule, HttpModuleOptions } from '@nestjs/axios';
-import { Global, Module } from '@nestjs/common';
+import { Global, Logger, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
@@ -19,6 +19,15 @@ export const DEFAULT_DATABASE_TIMEOUT_MS = 60_000;
 export const DEFAULT_DATABASE_MAX_SOCKETS = 50;
 
 /**
+ * Lower bound for the request timeout. The internal changes feed issues 50s
+ * longpoll requests through the same HTTP client; a timeout at or below that
+ * window would abort the feed every cycle (breaking permission-change
+ * propagation and identity-cache invalidation), so a too-low configured value
+ * is clamped up to this floor.
+ */
+export const MIN_DATABASE_TIMEOUT_MS = 55_000;
+
+/**
  * HTTP client options for all requests to CouchDB:
  *
  * - a request timeout, so that a hung CouchDB connection (e.g. half-open
@@ -30,9 +39,15 @@ export const DEFAULT_DATABASE_MAX_SOCKETS = 50;
 export function couchdbHttpOptions(
   configService: ConfigService,
 ): HttpModuleOptions {
-  const timeout =
+  const configuredTimeout =
     Number(configService.get(DATABASE_TIMEOUT_ENV)) ||
     DEFAULT_DATABASE_TIMEOUT_MS;
+  const timeout = Math.max(configuredTimeout, MIN_DATABASE_TIMEOUT_MS);
+  if (configuredTimeout < MIN_DATABASE_TIMEOUT_MS) {
+    new Logger('CouchdbModule').warn(
+      `${DATABASE_TIMEOUT_ENV}=${configuredTimeout}ms is below the ${MIN_DATABASE_TIMEOUT_MS}ms floor (the internal changes feed uses 50s longpoll requests); using ${timeout}ms instead.`,
+    );
+  }
   const maxSockets =
     Number(configService.get(DATABASE_MAX_SOCKETS_ENV)) ||
     DEFAULT_DATABASE_MAX_SOCKETS;

--- a/src/couchdb/couchdb.module.ts
+++ b/src/couchdb/couchdb.module.ts
@@ -1,11 +1,57 @@
-import { HttpModule } from '@nestjs/axios';
+import { HttpModule, HttpModuleOptions } from '@nestjs/axios';
 import { Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
 import { CouchdbService } from './couchdb.service';
 import { DocumentChangesService } from './document-changes.service';
 
+/**
+ * (optional) env var: per-request timeout in ms for requests to CouchDB.
+ * Must stay above ~55s — the internal changes feed uses 50s longpoll
+ * requests that must not be aborted client-side.
+ */
+export const DATABASE_TIMEOUT_ENV = 'DATABASE_TIMEOUT_MS';
+/** (optional) env var: maximum number of parallel connections to CouchDB */
+export const DATABASE_MAX_SOCKETS_ENV = 'DATABASE_MAX_SOCKETS';
+
+export const DEFAULT_DATABASE_TIMEOUT_MS = 60_000;
+export const DEFAULT_DATABASE_MAX_SOCKETS = 50;
+
+/**
+ * HTTP client options for all requests to CouchDB:
+ *
+ * - a request timeout, so that a hung CouchDB connection (e.g. half-open
+ *   socket) fails the request and triggers retries instead of hanging the
+ *   client forever
+ * - keep-alive agents with a socket cap, so request bursts reuse
+ *   connections instead of opening an unbounded number of new ones
+ */
+export function couchdbHttpOptions(
+  configService: ConfigService,
+): HttpModuleOptions {
+  const timeout =
+    Number(configService.get(DATABASE_TIMEOUT_ENV)) ||
+    DEFAULT_DATABASE_TIMEOUT_MS;
+  const maxSockets =
+    Number(configService.get(DATABASE_MAX_SOCKETS_ENV)) ||
+    DEFAULT_DATABASE_MAX_SOCKETS;
+  const agentOptions = { keepAlive: true, maxSockets };
+  return {
+    timeout,
+    httpAgent: new HttpAgent(agentOptions),
+    httpsAgent: new HttpsAgent(agentOptions),
+  };
+}
+
 @Global()
 @Module({
-  imports: [HttpModule],
+  imports: [
+    HttpModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: couchdbHttpOptions,
+    }),
+  ],
   providers: [CouchdbService, DocumentChangesService],
   exports: [CouchdbService, DocumentChangesService],
 })

--- a/src/couchdb/couchdb.module.ts
+++ b/src/couchdb/couchdb.module.ts
@@ -39,18 +39,22 @@ export const MIN_DATABASE_TIMEOUT_MS = 55_000;
 export function couchdbHttpOptions(
   configService: ConfigService,
 ): HttpModuleOptions {
+  const parsedTimeout = Number(configService.get(DATABASE_TIMEOUT_ENV));
   const configuredTimeout =
-    Number(configService.get(DATABASE_TIMEOUT_ENV)) ||
-    DEFAULT_DATABASE_TIMEOUT_MS;
+    Number.isFinite(parsedTimeout) && parsedTimeout > 0
+      ? parsedTimeout
+      : DEFAULT_DATABASE_TIMEOUT_MS;
   const timeout = Math.max(configuredTimeout, MIN_DATABASE_TIMEOUT_MS);
   if (configuredTimeout < MIN_DATABASE_TIMEOUT_MS) {
     new Logger('CouchdbModule').warn(
       `${DATABASE_TIMEOUT_ENV}=${configuredTimeout}ms is below the ${MIN_DATABASE_TIMEOUT_MS}ms floor (the internal changes feed uses 50s longpoll requests); using ${timeout}ms instead.`,
     );
   }
+  const parsedMaxSockets = Number(configService.get(DATABASE_MAX_SOCKETS_ENV));
   const maxSockets =
-    Number(configService.get(DATABASE_MAX_SOCKETS_ENV)) ||
-    DEFAULT_DATABASE_MAX_SOCKETS;
+    Number.isFinite(parsedMaxSockets) && parsedMaxSockets > 0
+      ? parsedMaxSockets
+      : DEFAULT_DATABASE_MAX_SOCKETS;
   const agentOptions = { keepAlive: true, maxSockets };
   return {
     timeout,


### PR DESCRIPTION
## Summary

Part of #261 (item 4). Based on #262 (e2e suite) — merge that first; GitHub retargets automatically. Independent of the other improvement PRs.

Two stability gaps in the CouchDB HTTP client:

- **No request timeout anywhere** — a hung CouchDB connection (half-open socket, stalled network) hangs the client request forever. The internal longpoll changes feed could stall silently too: its `timeout=50000` parameter only controls the *server-side* longpoll window, not the client socket.
- **No explicit keep-alive agent with a socket cap** — request bursts (many syncing clients) could open an unbounded number of connections to CouchDB.

## Changes

- `CouchdbModule` now registers `HttpModule` with an exported, unit-tested factory (`couchdbHttpOptions`):
  - `timeout`: default **60 s** (`DATABASE_TIMEOUT_MS`) — safely above the 50 s longpoll window, so feed requests are never aborted client-side while idle
  - `httpAgent`/`httpsAgent`: keep-alive, default **50 sockets max** (`DATABASE_MAX_SOCKETS`)
- New env vars documented in README and `.env.template`; invalid values fall back to defaults.

When a timeout strikes the changes feed, the existing retry-with-backoff logic in `DocumentChangesService` takes over — previously the feed would just hang with no recovery.

## Test plan

- new unit tests for the options factory (defaults, env overrides, invalid value fallback)
- full suite: 177 unit / 40 e2e green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CouchDB connection settings for request timeouts and maximum keep-alive sockets.
  * CouchDB connections now reuse sockets and apply configurable connection limits.

* **Bug Fixes**
  * Prevented excessively short timeouts from interrupting long-running feed requests.
  * Invalid connection settings now safely fall back to defaults.

* **Documentation**
  * Updated setup documentation with the new optional environment variables.

* **Tests**
  * Added coverage for defaults, overrides, invalid values, socket limits, and timeout safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->