### PR TITLE
perf: efficiency fixes in replication bulk endpoints

### DIFF
--- a/src/restricted-endpoints/replication/bulk-document/bulk-document.service.spec.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-document.service.spec.ts
@@ -100,6 +100,18 @@ describe('BulkDocumentService', () => {
     expect(result).toEqual(createAllDocsResponse(childDoc));
   });
 
+  it('should pass through error rows (missing keys) in AllDocs without crashing', () => {
+    const allDocsResponse = createAllDocsResponse(schoolDoc);
+    // CouchDB returns rows without an `id` for unknown keys
+    const errorRow = { key: 'School:missing', error: 'not_found' } as any;
+    allDocsResponse.rows.push(errorRow);
+
+    const result = service.filterAllDocsResponse(allDocsResponse, normalUser);
+
+    expect(result.rows).toContain(errorRow);
+    expect(result.rows).toHaveLength(2);
+  });
+
   it('should not filter out deleted docs in AllDocs', () => {
     const allDocsResponse = createAllDocsResponse(schoolDoc, childDoc);
     schoolDoc._deleted = true;

--- a/src/restricted-endpoints/replication/bulk-document/bulk-document.service.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-document.service.ts
@@ -75,8 +75,13 @@ export class BulkDocumentService {
       offset: response.offset,
       rows: response.rows.filter(
         (row) =>
-          this.documentFilter.isReplicable(row.id) &&
-          (row.doc ? row.doc._deleted || ability.can('read', row.doc) : true),
+          // rows without id are error entries for missing keys
+          // (e.g. {key, error: "not_found"}) and are passed through
+          !row.id ||
+          (this.documentFilter.isReplicable(row.id) &&
+            (row.doc
+              ? row.doc._deleted || ability.can('read', row.doc)
+              : true)),
       ),
     };
   }

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -99,7 +99,14 @@ export class ChangesController {
         remainingChangesUntilLimit,
       );
       totalFetched += res._totalFetchedFromCouch ?? 0;
-      change.results.push(...res.results);
+      if (params?.include_docs === 'true') {
+        change.results.push(...res.results);
+      } else {
+        // doc content not requested: drop the (potentially large) doc bodies
+        // per iteration instead of accumulating all of them in memory until
+        // the end of the loop
+        change.results.push(...res.results.map((c) => omit(c, 'doc')));
+      }
       if (change.lostPermissions) {
         change.lostPermissions.push(...(res.lostPermissions ?? []));
       }
@@ -116,10 +123,6 @@ export class ChangesController {
         break;
       }
       since = res.last_seq;
-    }
-    if (params?.include_docs !== 'true') {
-      // remove doc content if not requested
-      change.results = change.results.map((c) => omit(c, 'doc'));
     }
 
     const duration = Date.now() - startTime;

--- a/test/replication.e2e-spec.ts
+++ b/test/replication.e2e-spec.ts
@@ -169,6 +169,19 @@ describe('Replication endpoints (e2e)', () => {
       expect(ids).toEqual(['Child:1', 'Note:1']);
     });
 
+    it('passes through error rows for unknown keys', async () => {
+      const res = await request(ctx.app.getHttpServer())
+        .post('/app/_all_docs?include_docs=true')
+        .set(...basicAuth('user', 'user-pw'))
+        .send({ keys: ['Child:1', 'Child:does-not-exist'] })
+        .expect(201);
+      expect(res.body.rows).toHaveLength(2);
+      expect(res.body.rows[1]).toMatchObject({
+        key: 'Child:does-not-exist',
+        error: 'not_found',
+      });
+    });
+
     // TODO: fix filterAllDocsResponse to apply permission checks even when include_docs is absent,
     // so that unauthorized doc IDs/revs are not leaked as bare metadata rows.
     // After the fix, update the expectation below to exclude 'School:1'.


### PR DESCRIPTION
## Summary

Part of #261 (items 5 + 6). Based on #262 (e2e suite) — merge that first; GitHub retargets automatically. Independent of the other improvement PRs.

Three small, self-contained fixes in the replication hot path:

1. **`filterBulkDocsRequest` was O(n²)** — `response.rows.find(...)` inside a `.filter()` over the same docs (~10⁶ comparisons for a 1000-doc `_bulk_docs` push). Existing docs are now indexed in a `Map` once.
2. **`_changes` accumulated doc bodies needlessly** — when the client did not request `include_docs`, full doc bodies were still collected across all fetch iterations (potentially tens of MB) and only stripped at the end via a second full mapping pass. Bodies are now dropped per iteration.
3. **`_all_docs` crashed on unknown keys** — CouchDB returns `{key, error: "not_found"}` rows *without an `id`* for missing keys; `isReplicable(row.id)` then threw a `TypeError`, turning the whole request into a 500. Error rows are now passed through (consistent with how `_bulk_get` already handles error entries).

## Test plan

- new unit test: error rows in `filterAllDocsResponse` pass through unchanged
- new e2e test: `POST /:db/_all_docs` with an unknown key returns the `not_found` row instead of a 500
- existing `_bulk_docs` / `_changes` unit + e2e tests cover the refactored paths
- 175 unit / 41 e2e tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved replication responses for unknown document keys by preserving CouchDB error rows instead of filtering them out.
  - Ensured `_all_docs` requests with `include_docs=true` retain expected `not_found` entries for missing documents.
  - Streamlined processing of change results when document bodies are not requested.

- **Tests**
  - Added unit and end-to-end coverage for missing-document error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->