### PR TITLE
feat: allow creation of indices for authenticated users

### DIFF
--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
@@ -21,6 +21,7 @@ import {
   FindResponse,
 } from './couchdb-dtos/bulk-docs.dto';
 import { BulkGetRequest, BulkGetResponse } from './couchdb-dtos/bulk-get.dto';
+import { OnlyAuthenticated } from '../../../auth/only-authenticated.decorator';
 
 /**
  * Handle endpoints for the CouchDB replication process and bulk actions
@@ -84,6 +85,22 @@ export class BulkDocEndpointsController {
         return of(this.bulkDocumentService.filterFindResponse(response, user));
       }),
     );
+  }
+
+  /**
+   * Create an index to speed up queries using the '_find' endpoint.
+   * Indices are especially necessary when using sort inside a find-query.
+   * The request is directly forwarded to the CouchDB instance {@link https://docs.couchdb.org/en/stable/api/database/find.html#post--db-_index}.
+   * The user needs to be authenticated but no further permissions are enforced.
+   *
+   * @param db name of the database for which the index should be created
+   * @param body index definition, see CouchDB docs for more details
+   */
+  @Post('/:db/_index')
+  @OnlyAuthenticated()
+  @ApiOperation({ description: `Create new index for the '_find' endpoint` })
+  create_index(@Param('db') db: string, @Body() body: object) {
+    return from(this.couchdbService.post(db, '_index', body));
   }
 
   /**


### PR DESCRIPTION
Allows authenticated users to create indices for find queries (see [docs](https://docs.couchdb.org/en/stable/api/database/find.html#post--db-_index)).
This is needed for the [database pagination feature](https://github.com/Aam-Digital/ndb-core/pull/4046), especially for using `sort` inside a mango query an index needs to be available.

Users are only enforced to be logged in, no further permission checks are required.
The idea is that the indices are lazy-generated, meaning only when they are first needed.

Live on [https://load-test.aam-digital.net/](https://load-test.aam-digital.net/c/child)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new authenticated endpoint to create a database index for bulk document operations.
  * Requests to the new endpoint now forward the submitted payload directly to the backend service.

* **Security**
  * Restricted the new index-creation action so it is available only to signed-in users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->