### PR TITLE
docs: no production-specific data in public GitHub content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AI Agent Instructions
+
+CouchDB replication and permission proxy for [Aam Digital](https://github.com/Aam-Digital/ndb-core).
+See README.md for setup and development details.
+
+## Public GitHub Content (PRs, Issues, Comments, Commit Messages)
+
+This repository is public. Never include customer/project-identifying information or other
+production-system-specific data in anything posted to GitHub — no deployment/instance names,
+server hostnames, external partner URLs, user identifiers, or real record data. Share only
+generalized insights instead (e.g. "a large production instance", "an external webhook
+consumer"). Scrub quoted log or monitoring output before posting. Links to access-restricted
+internal tools (e.g. Sentry issues) are acceptable.


### PR DESCRIPTION
Adds an AGENTS.md guideline: PRs, issues, comments, and commit messages in this public repository must not contain customer/project-identifying information or production-system-specific data — only generalized insights. Mirrors Aam-Digital/aam-services#155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling sensitive information in shared content.
  * Clarified what should be excluded from public posts and logs, helping prevent accidental exposure of private data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->