### PR TITLE
feat: self-healing default permissions via write-back to permission document

### DIFF
--- a/src/permissions/rules/default-permissions.spec.ts
+++ b/src/permissions/rules/default-permissions.spec.ts
@@ -3,7 +3,7 @@ import {
   mergeManagedDefaults,
   SYSTEM_DEFAULT_MARKER,
 } from './default-permissions';
-import { DocumentRule } from './rules.service';
+import type { DocumentRule } from './rules.service';
 
 describe('mergeManagedDefaults', () => {
   const adminRule: DocumentRule = { action: 'read', subject: 'Child' };
@@ -18,6 +18,11 @@ describe('mergeManagedDefaults', () => {
     const fromEmpty = mergeManagedDefaults(undefined);
     expect(fromEmpty.changed).toBe(true);
     expect(fromEmpty.merged).toEqual(MANAGED_DEFAULT_RULES);
+
+    // a malformed (non-array) default section is healed instead of throwing
+    const fromMalformed = mergeManagedDefaults(null as any);
+    expect(fromMalformed.changed).toBe(true);
+    expect(fromMalformed.merged).toEqual(MANAGED_DEFAULT_RULES);
   });
 
   it('should report unchanged when managed defaults are already present', () => {
@@ -27,6 +32,7 @@ describe('mergeManagedDefaults', () => {
 
     expect(second.changed).toBe(false);
     expect(second.merged).toEqual(merged);
+    expect(second.dropped).toEqual([]);
   });
 
   it('should replace outdated system-default rules instead of duplicating them', () => {
@@ -36,9 +42,13 @@ describe('mergeManagedDefaults', () => {
       reason: `${SYSTEM_DEFAULT_MARKER} outdated rule`,
     };
 
-    const { merged, changed } = mergeManagedDefaults([outdated, adminRule]);
+    const { merged, changed, dropped } = mergeManagedDefaults([
+      outdated,
+      adminRule,
+    ]);
 
     expect(changed).toBe(true);
     expect(merged).toEqual([...MANAGED_DEFAULT_RULES, adminRule]);
+    expect(dropped).toEqual([outdated]);
   });
 });

--- a/src/permissions/rules/default-permissions.spec.ts
+++ b/src/permissions/rules/default-permissions.spec.ts
@@ -15,7 +15,7 @@ describe('mergeManagedDefaults', () => {
     expect(merged).toEqual([...MANAGED_DEFAULT_RULES, adminRule]);
 
     // a missing default section yields exactly the managed rules
-    const fromEmpty = mergeManagedDefaults(undefined);
+    const fromEmpty = mergeManagedDefaults();
     expect(fromEmpty.changed).toBe(true);
     expect(fromEmpty.merged).toEqual(MANAGED_DEFAULT_RULES);
 

--- a/src/permissions/rules/default-permissions.spec.ts
+++ b/src/permissions/rules/default-permissions.spec.ts
@@ -1,0 +1,44 @@
+import {
+  MANAGED_DEFAULT_RULES,
+  mergeManagedDefaults,
+  SYSTEM_DEFAULT_MARKER,
+} from './default-permissions';
+import { DocumentRule } from './rules.service';
+
+describe('mergeManagedDefaults', () => {
+  const adminRule: DocumentRule = { action: 'read', subject: 'Child' };
+
+  it('should prepend managed defaults before existing admin rules', () => {
+    const { merged, changed } = mergeManagedDefaults([adminRule]);
+
+    expect(changed).toBe(true);
+    expect(merged).toEqual([...MANAGED_DEFAULT_RULES, adminRule]);
+
+    // a missing default section yields exactly the managed rules
+    const fromEmpty = mergeManagedDefaults(undefined);
+    expect(fromEmpty.changed).toBe(true);
+    expect(fromEmpty.merged).toEqual(MANAGED_DEFAULT_RULES);
+  });
+
+  it('should report unchanged when managed defaults are already present', () => {
+    const { merged } = mergeManagedDefaults([adminRule]);
+
+    const second = mergeManagedDefaults(merged);
+
+    expect(second.changed).toBe(false);
+    expect(second.merged).toEqual(merged);
+  });
+
+  it('should replace outdated system-default rules instead of duplicating them', () => {
+    const outdated: DocumentRule = {
+      action: 'read',
+      subject: 'OldSubject',
+      reason: `${SYSTEM_DEFAULT_MARKER} outdated rule`,
+    };
+
+    const { merged, changed } = mergeManagedDefaults([outdated, adminRule]);
+
+    expect(changed).toBe(true);
+    expect(merged).toEqual([...MANAGED_DEFAULT_RULES, adminRule]);
+  });
+});

--- a/src/permissions/rules/default-permissions.ts
+++ b/src/permissions/rules/default-permissions.ts
@@ -13,6 +13,10 @@ export const SYSTEM_DEFAULT_MARKER = '[system-default]';
  * cannot lock itself out of core functionality. These are idempotently written
  * into the `default` section of the Config:Permissions document, prepended
  * (lowest CASL priority) so explicit admin rules can override them.
+ *
+ * During a rolling deploy, instances with a different managed set may rewrite
+ * each other's rules until the deploy completes. This flip-flop is transient
+ * and accepted; avoid long-running mixed-version deployments.
  */
 export const MANAGED_DEFAULT_RULES: DocumentRule[] = [
   {
@@ -47,6 +51,8 @@ export const MANAGED_DEFAULT_RULES: DocumentRule[] = [
     reason: `${SYSTEM_DEFAULT_MARKER} manage own notification config`,
   },
   {
+    // Ownership is enforced by the per-user notification databases, not by
+    // this rule; this rule only enables the frontend UI actions.
     action: 'manage',
     subject: 'NotificationEvent',
     reason: `${SYSTEM_DEFAULT_MARKER} manage own notification events`,
@@ -58,16 +64,35 @@ export const MANAGED_DEFAULT_RULES: DocumentRule[] = [
  * Managed rules are prepended and any previously written system-default rules
  * are replaced by the current managed set, so updated backend versions
  * refresh their own rules while admin-authored rules stay untouched.
+ *
+ * A non-array `currentDefault` (e.g. `null` from a malformed document) is
+ * treated the same as an empty section instead of throwing, so that a
+ * malformed `default` section gets actively healed rather than crashing the
+ * caller.
  */
 export function mergeManagedDefaults(currentDefault: DocumentRule[] = []): {
   merged: DocumentRule[];
   changed: boolean;
+  dropped: DocumentRule[];
 } {
-  const adminRules = currentDefault.filter(
+  const current = Array.isArray(currentDefault) ? currentDefault : [];
+  const adminRules = current.filter(
     (rule) =>
       typeof rule.reason !== 'string' ||
       !rule.reason.includes(SYSTEM_DEFAULT_MARKER),
   );
+  const removedMarkerRules = current.filter(
+    (rule) =>
+      typeof rule.reason === 'string' &&
+      rule.reason.includes(SYSTEM_DEFAULT_MARKER),
+  );
+  // Rules that carried the marker but do not match the current managed set:
+  // either outdated (superseded by a newer managed rule) or an admin's
+  // customized copy of a managed rule. Either way they are dropped here and
+  // worth a warning so an admin notices a customization was overwritten.
+  const dropped = removedMarkerRules.filter(
+    (rule) => !MANAGED_DEFAULT_RULES.some((managed) => isEqual(managed, rule)),
+  );
   const merged = [...MANAGED_DEFAULT_RULES, ...adminRules];
-  return { merged, changed: !isEqual(merged, currentDefault) };
+  return { merged, changed: !isEqual(merged, currentDefault), dropped };
 }

--- a/src/permissions/rules/default-permissions.ts
+++ b/src/permissions/rules/default-permissions.ts
@@ -1,0 +1,73 @@
+import { isEqual } from 'lodash';
+import type { DocumentRule } from './rules.service';
+
+/**
+ * Marker in a rule's `reason` field identifying rules that are managed by the
+ * backend itself. The write-back recognises and refreshes these rules without
+ * touching admin-authored rules.
+ */
+export const SYSTEM_DEFAULT_MARKER = '[system-default]';
+
+/**
+ * Essential baseline rules every authenticated user needs so that an instance
+ * cannot lock itself out of core functionality. These are idempotently written
+ * into the `default` section of the Config:Permissions document, prepended
+ * (lowest CASL priority) so explicit admin rules can override them.
+ */
+export const MANAGED_DEFAULT_RULES: DocumentRule[] = [
+  {
+    // All Config docs share the CASL subject "Config" (the _id prefix), so
+    // this rule must be scoped to specific _ids. Config backups such as
+    // "Config:CONFIG_ENTITY:<timestamp>" deliberately stay restrictable.
+    action: 'read',
+    subject: 'Config',
+    conditions: {
+      _id: {
+        $in: [
+          'Config:CONFIG_ENTITY',
+          'Config:Permissions',
+          'Config:NotificationConfigTemplate',
+        ],
+      },
+    },
+    reason: `${SYSTEM_DEFAULT_MARKER} core config read access`,
+  },
+  {
+    // edits are intentionally not granted here and stay denied by default
+    action: 'read',
+    subject: 'SiteSettings',
+    reason: `${SYSTEM_DEFAULT_MARKER} site settings read access`,
+  },
+  {
+    // NotificationConfig.userId holds the account id (Keycloak user id),
+    // which matches ${user.id} in both frontend and backend interpolation
+    action: 'manage',
+    subject: 'NotificationConfig',
+    conditions: { userId: '${user.id}' },
+    reason: `${SYSTEM_DEFAULT_MARKER} manage own notification config`,
+  },
+  {
+    action: 'manage',
+    subject: 'NotificationEvent',
+    reason: `${SYSTEM_DEFAULT_MARKER} manage own notification events`,
+  },
+];
+
+/**
+ * Merge the managed default rules into an existing `default` rules section.
+ * Managed rules are prepended and any previously written system-default rules
+ * are replaced by the current managed set, so updated backend versions
+ * refresh their own rules while admin-authored rules stay untouched.
+ */
+export function mergeManagedDefaults(currentDefault: DocumentRule[] = []): {
+  merged: DocumentRule[];
+  changed: boolean;
+} {
+  const adminRules = currentDefault.filter(
+    (rule) =>
+      typeof rule.reason !== 'string' ||
+      !rule.reason.includes(SYSTEM_DEFAULT_MARKER),
+  );
+  const merged = [...MANAGED_DEFAULT_RULES, ...adminRules];
+  return { merged, changed: !isEqual(merged, currentDefault) };
+}

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -8,6 +8,7 @@ import { DocumentChangesService } from '../../couchdb/document-changes.service';
 import { ChangeResult } from '../../restricted-endpoints/replication/bulk-document/couchdb-dtos/changes.dto';
 import { UserInfo } from '../../restricted-endpoints/session/user-auth.dto';
 import { UserIdentityService } from '../user-identity/user-identity.service';
+import { MANAGED_DEFAULT_RULES } from './default-permissions';
 import { Permission } from './permission';
 import { DocumentRule, RulesService } from './rules.service';
 
@@ -52,6 +53,9 @@ describe('RulesService', () => {
 
     mockCouchdbService = {
       get: jest.fn().mockReturnValue(of(testPermission)),
+      put: jest
+        .fn()
+        .mockReturnValue(of({ ok: true, id: Permission.DOC_ID, rev: '2-x' })),
     } as any;
 
     const mockDocumentChangesService = {
@@ -234,6 +238,43 @@ describe('RulesService', () => {
     expect(mockAdminService.clearLocal).toHaveBeenCalled();
 
     jest.useRealTimers();
+  });
+
+  it('should write managed default rules into the permission doc on startup', () => {
+    expect(mockCouchdbService.put).toHaveBeenCalledWith(
+      DATABASE_NAME,
+      expect.objectContaining({
+        _id: Permission.DOC_ID,
+        data: {
+          ...testPermission.data,
+          default: MANAGED_DEFAULT_RULES,
+        },
+      }),
+    );
+    // in-memory rules are not modified directly; the enriched doc arrives via the changes feed
+    expect(service.getRulesForUser(normalUser)).toEqual(userRules);
+  });
+
+  it('should not write when managed defaults are already present', async () => {
+    (mockCouchdbService.put as jest.Mock).mockClear();
+    testPermission.data.default = [...MANAGED_DEFAULT_RULES];
+
+    await service.onModuleInit();
+
+    expect(mockCouchdbService.put).not.toHaveBeenCalled();
+  });
+
+  it('should not write managed defaults in bootstrap mode', async () => {
+    const bootstrapPut = jest.fn();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    const { freshService } = await buildFreshService({
+      ...notFoundCouchdb(),
+      put: bootstrapPut,
+    } as any);
+
+    await freshService.onModuleInit();
+
+    expect(bootstrapPut).not.toHaveBeenCalled();
   });
 
   /**

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -241,50 +241,62 @@ describe('RulesService', () => {
   });
 
   it('should restore managed defaults when a change strips them', async () => {
-    (mockCouchdbService.put as jest.Mock).mockClear();
-    const adminRule: DocumentRule = { action: 'read', subject: 'Child' };
-    const strippedDoc = new Permission({
-      ...testPermission.data,
-      default: [adminRule],
-    });
-    strippedDoc._rev = '2-abc';
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+    try {
+      (mockCouchdbService.put as jest.Mock).mockClear();
+      const adminRule: DocumentRule = { action: 'read', subject: 'Child' };
+      const strippedDoc = new Permission({
+        ...testPermission.data,
+        default: [adminRule],
+      });
+      strippedDoc._rev = '2-abc';
 
-    changesSubject.next({
-      doc: strippedDoc,
-      id: Permission.DOC_ID,
-      seq: '3',
-      changes: [{ rev: '2-abc' }],
-    });
-    await new Promise(process.nextTick);
+      changesSubject.next({
+        doc: strippedDoc,
+        id: Permission.DOC_ID,
+        seq: '3',
+        changes: [{ rev: '2-abc' }],
+      });
+      await new Promise(process.nextTick);
+      jest.advanceTimersByTime(1500);
 
-    expect(mockCouchdbService.put).toHaveBeenCalledWith(
-      DATABASE_NAME,
-      expect.objectContaining({
-        _rev: '2-abc',
-        data: expect.objectContaining({
-          default: [...MANAGED_DEFAULT_RULES, adminRule],
+      expect(mockCouchdbService.put).toHaveBeenCalledWith(
+        DATABASE_NAME,
+        expect.objectContaining({
+          _rev: '2-abc',
+          data: expect.objectContaining({
+            default: [...MANAGED_DEFAULT_RULES, adminRule],
+          }),
         }),
-      }),
-    );
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('should not write again when a change already contains the managed defaults', async () => {
-    (mockCouchdbService.put as jest.Mock).mockClear();
-    const enrichedDoc = new Permission({
-      ...testPermission.data,
-      default: [...MANAGED_DEFAULT_RULES],
-    });
-    enrichedDoc._rev = '2-abc';
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+    try {
+      (mockCouchdbService.put as jest.Mock).mockClear();
+      const enrichedDoc = new Permission({
+        ...testPermission.data,
+        default: [...MANAGED_DEFAULT_RULES],
+      });
+      enrichedDoc._rev = '2-abc';
 
-    changesSubject.next({
-      doc: enrichedDoc,
-      id: Permission.DOC_ID,
-      seq: '3',
-      changes: [{ rev: '2-abc' }],
-    });
-    await new Promise(process.nextTick);
+      changesSubject.next({
+        doc: enrichedDoc,
+        id: Permission.DOC_ID,
+        seq: '3',
+        changes: [{ rev: '2-abc' }],
+      });
+      await new Promise(process.nextTick);
+      jest.advanceTimersByTime(1500);
 
-    expect(mockCouchdbService.put).not.toHaveBeenCalled();
+      expect(mockCouchdbService.put).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('should retry with the current doc when the write-back hits a rev conflict', async () => {

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -240,6 +240,79 @@ describe('RulesService', () => {
     jest.useRealTimers();
   });
 
+  it('should restore managed defaults when a change strips them', async () => {
+    (mockCouchdbService.put as jest.Mock).mockClear();
+    const adminRule: DocumentRule = { action: 'read', subject: 'Child' };
+    const strippedDoc = new Permission({
+      ...testPermission.data,
+      default: [adminRule],
+    });
+    strippedDoc._rev = '2-abc';
+
+    changesSubject.next({
+      doc: strippedDoc,
+      id: Permission.DOC_ID,
+      seq: '3',
+      changes: [{ rev: '2-abc' }],
+    });
+    await new Promise(process.nextTick);
+
+    expect(mockCouchdbService.put).toHaveBeenCalledWith(
+      DATABASE_NAME,
+      expect.objectContaining({
+        _rev: '2-abc',
+        data: expect.objectContaining({
+          default: [...MANAGED_DEFAULT_RULES, adminRule],
+        }),
+      }),
+    );
+  });
+
+  it('should not write again when a change already contains the managed defaults', async () => {
+    (mockCouchdbService.put as jest.Mock).mockClear();
+    const enrichedDoc = new Permission({
+      ...testPermission.data,
+      default: [...MANAGED_DEFAULT_RULES],
+    });
+    enrichedDoc._rev = '2-abc';
+
+    changesSubject.next({
+      doc: enrichedDoc,
+      id: Permission.DOC_ID,
+      seq: '3',
+      changes: [{ rev: '2-abc' }],
+    });
+    await new Promise(process.nextTick);
+
+    expect(mockCouchdbService.put).not.toHaveBeenCalled();
+  });
+
+  it('should retry with the current doc when the write-back hits a rev conflict', async () => {
+    (mockCouchdbService.put as jest.Mock)
+      .mockClear()
+      .mockReturnValueOnce(
+        throwError(() => new HttpException('conflict', HttpStatus.CONFLICT)),
+      )
+      .mockReturnValue(of({ ok: true, id: Permission.DOC_ID, rev: '4-a' }));
+    const currentDoc = new Permission({ ...testPermission.data });
+    currentDoc._rev = '3-newer';
+    (mockCouchdbService.get as jest.Mock).mockReturnValue(of(currentDoc));
+
+    changesSubject.next({
+      doc: new Permission({ ...testPermission.data }),
+      id: Permission.DOC_ID,
+      seq: '4',
+      changes: [{ rev: '2-b' }],
+    });
+    await new Promise(process.nextTick);
+
+    expect(mockCouchdbService.put).toHaveBeenCalledTimes(2);
+    expect(mockCouchdbService.put).toHaveBeenLastCalledWith(
+      DATABASE_NAME,
+      expect.objectContaining({ _rev: '3-newer' }),
+    );
+  });
+
   it('should write managed default rules into the permission doc on startup', () => {
     expect(mockCouchdbService.put).toHaveBeenCalledWith(
       DATABASE_NAME,

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -274,6 +274,39 @@ describe('RulesService', () => {
     }
   });
 
+  it('should heal a malformed (non-array) default section without crashing', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+    try {
+      (mockCouchdbService.put as jest.Mock).mockClear();
+      const malformedDoc = new Permission({
+        ...testPermission.data,
+        default: null as any,
+      });
+      malformedDoc._rev = '2-abc';
+
+      changesSubject.next({
+        doc: malformedDoc,
+        id: Permission.DOC_ID,
+        seq: '3',
+        changes: [{ rev: '2-abc' }],
+      });
+      await new Promise(process.nextTick);
+      jest.advanceTimersByTime(1500);
+
+      expect(mockCouchdbService.put).toHaveBeenCalledWith(
+        DATABASE_NAME,
+        expect.objectContaining({
+          _rev: '2-abc',
+          data: expect.objectContaining({
+            default: MANAGED_DEFAULT_RULES,
+          }),
+        }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('should not write again when a change already contains the managed defaults', async () => {
     jest.useFakeTimers({ doNotFake: ['nextTick'] });
     try {

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -270,7 +270,7 @@ describe('RulesService', () => {
     const { freshService } = await buildFreshService({
       ...notFoundCouchdb(),
       put: bootstrapPut,
-    } as any);
+    });
 
     await freshService.onModuleInit();
 
@@ -284,11 +284,18 @@ describe('RulesService', () => {
    */
   async function buildFreshService(couchdbServiceOverride: {
     get: jest.Mock;
+    put?: jest.Mock;
   }): Promise<{
     freshService: RulesService;
     freshChangesSubject: Subject<ChangeResult>;
   }> {
     const freshChangesSubject = new Subject<ChangeResult>();
+    const couchdbMock = {
+      put: jest
+        .fn()
+        .mockReturnValue(of({ ok: true, id: Permission.DOC_ID, rev: '2-x' })),
+      ...couchdbServiceOverride,
+    };
     const freshModule = await Test.createTestingModule({
       providers: [
         RulesService,
@@ -300,7 +307,7 @@ describe('RulesService', () => {
         },
         { provide: AdminService, useValue: mockAdminService },
         { provide: UserIdentityService, useValue: mockUserIdentityService },
-        { provide: CouchdbService, useValue: couchdbServiceOverride },
+        { provide: CouchdbService, useValue: couchdbMock },
         {
           provide: DocumentChangesService,
           useValue: {

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -223,69 +223,75 @@ export class RulesService implements OnModuleInit {
    * event triggers another attempt (self-healing).
    */
   private async ensureManagedDefaults(db: string, doc: Permission) {
-    for (let attempt = 0; attempt < 3; attempt++) {
-      try {
-        if (!PermissionConfigValidator.isValidRulesConfig(doc?.data)) {
-          return;
-        }
-        const { merged, changed, dropped } = mergeManagedDefaults(
-          doc.data.default,
+    try {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const outcome = await this.writeManagedDefaults(
+          db,
+          doc,
+          attempt === 2,
         );
-        if (!changed) {
+        if (outcome !== 'conflict') {
           return;
         }
-        if (dropped.length > 0) {
-          this.logger.warn(
-            `Customized rule(s) carrying the "${SYSTEM_DEFAULT_MARKER}" marker were replaced in "${db}": ${JSON.stringify(dropped)}`,
-          );
-        }
-
-        const updatedDoc: Permission = {
-          ...doc,
-          data: { ...doc.data, default: merged },
-        };
-        try {
-          await firstValueFrom(this.couchdbService.put(db, updatedDoc));
-          this.logger.log(
-            `Managed default permissions written to "${Permission.DOC_ID}" in "${db}"`,
-          );
-          return;
-        } catch (error) {
-          const isConflict =
-            error instanceof HttpException &&
-            error.getStatus() === HttpStatus.CONFLICT;
-          if (!isConflict || attempt === 2) {
-            this.logger.error(
-              `Failed to write managed default permissions to "${db}"`,
-              error instanceof Error ? error.stack : String(error),
-            );
-            return;
-          }
-          try {
-            doc = await firstValueFrom(
-              this.couchdbService.get<Permission>(db, Permission.DOC_ID),
-            );
-          } catch (fetchError) {
-            this.logger.error(
-              `Failed to re-fetch permission doc after write conflict in "${db}"`,
-              fetchError instanceof Error
-                ? fetchError.stack
-                : String(fetchError),
-            );
-            return;
-          }
-        }
-      } catch (unexpectedError) {
-        // Belt-and-braces: this method must never throw, even if the merge
-        // logic itself misbehaves in the future.
-        this.logger.error(
-          `Unexpected error while ensuring managed default permissions for "${db}"`,
-          unexpectedError instanceof Error
-            ? unexpectedError.stack
-            : String(unexpectedError),
+        doc = await firstValueFrom(
+          this.couchdbService.get<Permission>(db, Permission.DOC_ID),
         );
-        return;
       }
+    } catch (error) {
+      // Belt-and-braces: this method must never throw, even if the merge
+      // logic or the conflict re-fetch misbehaves; the next change event
+      // triggers another attempt (self-healing).
+      this.logger.error(
+        `Failed to write managed default permissions to "${db}"`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+  }
+
+  /**
+   * One write-back attempt: merge the managed defaults into the doc and PUT
+   * it if anything changed. Returns "conflict" when the PUT hit a rev
+   * conflict and retrying with a freshly fetched doc makes sense; rethrows
+   * any other error for {@link ensureManagedDefaults} to log.
+   */
+  private async writeManagedDefaults(
+    db: string,
+    doc: Permission,
+    isLastAttempt: boolean,
+  ): Promise<'done' | 'conflict'> {
+    if (!PermissionConfigValidator.isValidRulesConfig(doc?.data)) {
+      return 'done';
+    }
+    const { merged, changed, dropped } = mergeManagedDefaults(
+      doc.data.default,
+    );
+    if (!changed) {
+      return 'done';
+    }
+    if (dropped.length > 0) {
+      this.logger.warn(
+        `Customized rule(s) carrying the "${SYSTEM_DEFAULT_MARKER}" marker were replaced in "${db}": ${JSON.stringify(dropped)}`,
+      );
+    }
+
+    const updatedDoc: Permission = {
+      ...doc,
+      data: { ...doc.data, default: merged },
+    };
+    try {
+      await firstValueFrom(this.couchdbService.put(db, updatedDoc));
+      this.logger.log(
+        `Managed default permissions written to "${Permission.DOC_ID}" in "${db}"`,
+      );
+      return 'done';
+    } catch (error) {
+      const isConflict =
+        error instanceof HttpException &&
+        error.getStatus() === HttpStatus.CONFLICT;
+      if (isConflict && !isLastAttempt) {
+        return 'conflict';
+      }
+      throw error;
     }
   }
 

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -207,7 +207,8 @@ export class RulesService implements OnModuleInit {
                 );
               }),
           1000,
-        );
+          // a pending clearLocal must not keep the process alive on shutdown
+        ).unref();
       }
 
       void this.ensureManagedDefaults(db, change.doc as Permission);

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -273,6 +273,9 @@ export class RulesService implements OnModuleInit {
       ...doc,
       data: { ...doc.data, default: merged },
     };
+    this.logger.debug(
+      `Writing managed default permissions to "${db}" (rev ${doc._rev ?? 'none'})`,
+    );
     try {
       await firstValueFrom(this.couchdbService.put(db, updatedDoc));
       if (dropped.length > 0) {
@@ -291,6 +294,9 @@ export class RulesService implements OnModuleInit {
         error instanceof HttpException &&
         error.getStatus() === HttpStatus.CONFLICT;
       if (isConflict && !isLastAttempt) {
+        this.logger.debug(
+          `Failed to write managed default permissions to "${db}" due to rev conflict, retrying with fresh doc`,
+        );
         return 'conflict';
       }
       throw error;

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -1,6 +1,7 @@
 import { RawRuleOf } from '@casl/ability';
 import {
   HttpException,
+  HttpStatus,
   Injectable,
   Logger,
   OnModuleInit,
@@ -16,6 +17,7 @@ import { DocumentChangesService } from '../../couchdb/document-changes.service';
 import { UserInfo } from '../../restricted-endpoints/session/user-auth.dto';
 import { DocumentAbility } from '../permission/permission.service';
 import { UserIdentityService } from '../user-identity/user-identity.service';
+import { mergeManagedDefaults } from './default-permissions';
 import { Permission, RulesConfig } from './permission';
 import { PermissionConfigValidator } from './permission-config.validator';
 
@@ -94,6 +96,7 @@ export class RulesService implements OnModuleInit {
         if (this.permission === undefined) {
           this.permission = data;
         }
+        await this.ensureManagedDefaults(db, permissionDoc);
         return;
       } catch (error) {
         if (error instanceof HttpException && error.getStatus() === 404) {
@@ -205,6 +208,63 @@ export class RulesService implements OnModuleInit {
       }
     });
   }
+
+  /**
+   * Idempotently write the managed system-default rules into the `default`
+   * section of the permission document (see {@link MANAGED_DEFAULT_RULES}).
+   * Retries on rev conflicts with a freshly fetched doc so that concurrent
+   * admin edits or multiple backend instances converge. Never throws: a
+   * failed write-back must not break permission loading, and the next change
+   * event triggers another attempt (self-healing).
+   */
+  private async ensureManagedDefaults(db: string, doc: Permission) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      if (!PermissionConfigValidator.isValidRulesConfig(doc?.data)) {
+        return;
+      }
+      const { merged, changed } = mergeManagedDefaults(doc.data.default);
+      if (!changed) {
+        return;
+      }
+
+      const updatedDoc: Permission = {
+        ...doc,
+        data: { ...doc.data, default: merged },
+      };
+      try {
+        await firstValueFrom(this.couchdbService.put(db, updatedDoc));
+        this.logger.log(
+          `Managed default permissions written to "${Permission.DOC_ID}" in "${db}"`,
+        );
+        return;
+      } catch (error) {
+        const isConflict =
+          error instanceof HttpException &&
+          error.getStatus() === HttpStatus.CONFLICT;
+        if (!isConflict || attempt === 2) {
+          this.logger.error(
+            `Failed to write managed default permissions to "${db}"`,
+            error instanceof Error ? error.stack : String(error),
+          );
+          return;
+        }
+        try {
+          doc = await firstValueFrom(
+            this.couchdbService.get<Permission>(db, Permission.DOC_ID),
+          );
+        } catch (fetchError) {
+          this.logger.error(
+            `Failed to re-fetch permission doc after write conflict in "${db}"`,
+            fetchError instanceof Error
+              ? fetchError.stack
+              : String(fetchError),
+          );
+          return;
+        }
+      }
+    }
+  }
+
   /**
    * Get all rules that are related to the roles of the user.
    *

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -269,18 +269,19 @@ export class RulesService implements OnModuleInit {
     if (!changed) {
       return 'done';
     }
-    if (dropped.length > 0) {
-      this.logger.warn(
-        `Customized rule(s) carrying the "${SYSTEM_DEFAULT_MARKER}" marker were replaced in "${db}": ${JSON.stringify(dropped)}`,
-      );
-    }
-
     const updatedDoc: Permission = {
       ...doc,
       data: { ...doc.data, default: merged },
     };
     try {
       await firstValueFrom(this.couchdbService.put(db, updatedDoc));
+      if (dropped.length > 0) {
+        // warn only after the write persisted, so a failed or conflicting
+        // attempt does not falsely claim rules were replaced
+        this.logger.warn(
+          `Customized rule(s) carrying the "${SYSTEM_DEFAULT_MARKER}" marker were replaced in "${db}": ${JSON.stringify(dropped)}`,
+        );
+      }
       this.logger.log(
         `Managed default permissions written to "${Permission.DOC_ID}" in "${db}"`,
       );

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -17,7 +17,10 @@ import { DocumentChangesService } from '../../couchdb/document-changes.service';
 import { UserInfo } from '../../restricted-endpoints/session/user-auth.dto';
 import { DocumentAbility } from '../permission/permission.service';
 import { UserIdentityService } from '../user-identity/user-identity.service';
-import { mergeManagedDefaults } from './default-permissions';
+import {
+  mergeManagedDefaults,
+  SYSTEM_DEFAULT_MARKER,
+} from './default-permissions';
 import { Permission, RulesConfig } from './permission';
 import { PermissionConfigValidator } from './permission-config.validator';
 
@@ -221,48 +224,67 @@ export class RulesService implements OnModuleInit {
    */
   private async ensureManagedDefaults(db: string, doc: Permission) {
     for (let attempt = 0; attempt < 3; attempt++) {
-      if (!PermissionConfigValidator.isValidRulesConfig(doc?.data)) {
-        return;
-      }
-      const { merged, changed } = mergeManagedDefaults(doc.data.default);
-      if (!changed) {
-        return;
-      }
-
-      const updatedDoc: Permission = {
-        ...doc,
-        data: { ...doc.data, default: merged },
-      };
       try {
-        await firstValueFrom(this.couchdbService.put(db, updatedDoc));
-        this.logger.log(
-          `Managed default permissions written to "${Permission.DOC_ID}" in "${db}"`,
+        if (!PermissionConfigValidator.isValidRulesConfig(doc?.data)) {
+          return;
+        }
+        const { merged, changed, dropped } = mergeManagedDefaults(
+          doc.data.default,
+        );
+        if (!changed) {
+          return;
+        }
+        if (dropped.length > 0) {
+          this.logger.warn(
+            `Customized rule(s) carrying the "${SYSTEM_DEFAULT_MARKER}" marker were replaced in "${db}": ${JSON.stringify(dropped)}`,
+          );
+        }
+
+        const updatedDoc: Permission = {
+          ...doc,
+          data: { ...doc.data, default: merged },
+        };
+        try {
+          await firstValueFrom(this.couchdbService.put(db, updatedDoc));
+          this.logger.log(
+            `Managed default permissions written to "${Permission.DOC_ID}" in "${db}"`,
+          );
+          return;
+        } catch (error) {
+          const isConflict =
+            error instanceof HttpException &&
+            error.getStatus() === HttpStatus.CONFLICT;
+          if (!isConflict || attempt === 2) {
+            this.logger.error(
+              `Failed to write managed default permissions to "${db}"`,
+              error instanceof Error ? error.stack : String(error),
+            );
+            return;
+          }
+          try {
+            doc = await firstValueFrom(
+              this.couchdbService.get<Permission>(db, Permission.DOC_ID),
+            );
+          } catch (fetchError) {
+            this.logger.error(
+              `Failed to re-fetch permission doc after write conflict in "${db}"`,
+              fetchError instanceof Error
+                ? fetchError.stack
+                : String(fetchError),
+            );
+            return;
+          }
+        }
+      } catch (unexpectedError) {
+        // Belt-and-braces: this method must never throw, even if the merge
+        // logic itself misbehaves in the future.
+        this.logger.error(
+          `Unexpected error while ensuring managed default permissions for "${db}"`,
+          unexpectedError instanceof Error
+            ? unexpectedError.stack
+            : String(unexpectedError),
         );
         return;
-      } catch (error) {
-        const isConflict =
-          error instanceof HttpException &&
-          error.getStatus() === HttpStatus.CONFLICT;
-        if (!isConflict || attempt === 2) {
-          this.logger.error(
-            `Failed to write managed default permissions to "${db}"`,
-            error instanceof Error ? error.stack : String(error),
-          );
-          return;
-        }
-        try {
-          doc = await firstValueFrom(
-            this.couchdbService.get<Permission>(db, Permission.DOC_ID),
-          );
-        } catch (fetchError) {
-          this.logger.error(
-            `Failed to re-fetch permission doc after write conflict in "${db}"`,
-            fetchError instanceof Error
-              ? fetchError.stack
-              : String(fetchError),
-          );
-          return;
-        }
       }
     }
   }

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -206,6 +206,8 @@ export class RulesService implements OnModuleInit {
           1000,
         );
       }
+
+      void this.ensureManagedDefaults(db, change.doc as Permission);
     });
   }
 

--- a/test/replication.e2e-spec.ts
+++ b/test/replication.e2e-spec.ts
@@ -44,10 +44,10 @@ describe('Replication endpoints (e2e)', () => {
       expect(ids).toContain('Child:2');
       expect(ids).toContain('Note:1');
       expect(ids).toContain('Child:deleted'); // tombstones pass through
+      expect(ids).toContain('Config:Permissions'); // readable via managed system defaults
       expect(ids).not.toContain('School:1');
       expect(ids).not.toContain('Note:2');
       expect(ids).not.toContain('_design/some-view'); // filtered prefix
-      expect(ids).not.toContain('Config:Permissions');
 
       // notifies the client to purge docs it may no longer access
       expect(res.body.lostPermissions).toContain('School:1');


### PR DESCRIPTION
closes #229

Out of scope, per the issue discussion: feature-specific permission prompts (`ImportMetadata`, `EmailTemplate`, ...) and the frontend editor guard for `Config:Permissions` (separate ndb-core change).

## Manual Testing Steps

Verified on a local dev stack (CouchDB + Keycloak + this backend built from the branch):

1. Start the backend against a database with an existing `Config:Permissions` document. Log shows `Managed default permissions written to "Config:Permissions"`; the document's `data.default` now starts with the four `[system-default]` rules, followed by any pre-existing default rules; all other sections are untouched.
2. Restart the backend: no second write log, document revision unchanged (idempotent).
3. Manually remove one `[system-default]` rule from the document (e.g. via Fauxton): within seconds the backend restores it and logs the write; the revision stabilizes afterwards (no write loop).
4. Add a custom rule whose `reason` contains `[system-default]`: on the next write-back it is replaced and a warning names the replaced rule.
5. Set `data.default` to `null`: the backend heals it to the managed set without crashing.
6. As an authenticated user whose roles grant nothing relevant: `GET` on `Config:CONFIG_ENTITY`, `Config:Permissions` and `SiteSettings:global` succeed via the managed defaults alone, while a `PUT` on `SiteSettings:global` is denied (soft-lock).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added managed default permission rules for essential configuration access and notifications.
  - Automatically restores missing or malformed defaults during startup and permission updates.
  - Preserves administrator-defined rules while replacing outdated managed rules.
  - Added conflict-aware retries when saving updated permissions.

- **Bug Fixes**
  - Permission replication now correctly includes the configuration permissions document while filtering unrelated records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->