### PR TITLE
fix: log bulk-docs pushes silently dropped for missing write permission

### DIFF
--- a/src/restricted-endpoints/replication/bulk-document/bulk-document.service.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-document.service.ts
@@ -172,10 +172,10 @@ export class BulkDocumentService {
       // Dropped docs get no error entry in the _bulk_docs response, so the
       // client's replication checkpoints past them and never retries:
       // the doc silently stays local-only. Log to make this traceable.
-      this.logger.warn(
-        `_bulk_docs: dropped doc(s) without write permission`,
-        { user: user?.name, ids: deniedIds },
-      );
+      this.logger.warn(`_bulk_docs: dropped doc(s) without write permission`, {
+        user: user?.name,
+        ids: deniedIds,
+      });
     }
 
     return {

--- a/src/restricted-endpoints/replication/bulk-document/bulk-document.service.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-document.service.ts
@@ -173,7 +173,7 @@ export class BulkDocumentService {
       // client's replication checkpoints past them and never retries:
       // the doc silently stays local-only. Log to make this traceable.
       this.logger.warn(
-        `_bulk_docs: dropped ${deniedIds.length} doc(s) without write permission`,
+        `_bulk_docs: dropped doc(s) without write permission`,
         { user: user?.name, ids: deniedIds },
       );
     }

--- a/src/restricted-endpoints/replication/bulk-document/bulk-document.service.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-document.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import {
   BulkGetResponse,
   BulkGetResult,
@@ -29,6 +29,8 @@ import { AuditService } from '../../../audit/audit.service';
  */
 @Injectable()
 export class BulkDocumentService {
+  private readonly logger = new Logger(BulkDocumentService.name);
+
   constructor(
     private readonly permissionService: PermissionService,
     private readonly couchdbService: CouchdbService,
@@ -153,14 +155,32 @@ export class BulkDocumentService {
     existingDocs: Map<string, DatabaseDocument>,
   ): BulkDocsRequest {
     const ability = this.permissionService.getAbilityFor(user);
+    const permitted: DatabaseDocument[] = [];
+    const deniedIds: string[] = [];
+    for (const doc of request.docs) {
+      if (!doc._id || !this.documentFilter.isReplicable(doc._id)) {
+        continue;
+      }
+      if (this.hasPermissionsForDoc(doc, existingDocs.get(doc._id), ability)) {
+        permitted.push(doc);
+      } else {
+        deniedIds.push(doc._id);
+      }
+    }
+
+    if (deniedIds.length > 0) {
+      // Dropped docs get no error entry in the _bulk_docs response, so the
+      // client's replication checkpoints past them and never retries:
+      // the doc silently stays local-only. Log to make this traceable.
+      this.logger.warn(
+        `_bulk_docs: dropped ${deniedIds.length} doc(s) without write permission`,
+        { user: user?.name, ids: deniedIds },
+      );
+    }
+
     return {
       new_edits: request.new_edits,
-      docs: request.docs.filter(
-        (doc) =>
-          !!doc._id &&
-          this.documentFilter.isReplicable(doc._id) &&
-          this.hasPermissionsForDoc(doc, existingDocs.get(doc._id), ability),
-      ),
+      docs: permitted,
     };
   }
 


### PR DESCRIPTION
## Summary
Part of the investigation into [Aam-Digital/ndb-core#4178](https://github.com/Aam-Digital/ndb-core/issues/4178) (locally created data silently lost).

- `BulkDocumentService.filterDocs` removed docs the user lacks write permission for from the `_bulk_docs` request with no error entry in the response. PouchDB treats this as a successful write, checkpoints past the doc, and never retries — the doc is stuck local-only on the client with no trace anywhere.
- This PR adds a warn-level log (doc IDs + user) whenever this happens, so the case is now traceable instead of silent. No behavior change to what gets synced.

## Test plan
- [x] `bulk-document.service.spec.ts` passes (16/16)
- [x] `nest build` succeeds
- [x] `prettier --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk document permission filtering so only authorized documents are processed.
  * Added clearer warning visibility when requested documents are denied, while preserving supported request options (including `new_edits`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->