### PR TITLE
fix(sentry): fingerprint HttpExceptions so CouchDB faults stop merging into one issue

### DIFF
--- a/src/sentry.configuration.spec.ts
+++ b/src/sentry.configuration.spec.ts
@@ -1,4 +1,6 @@
-import { normalizeLogMessage } from './sentry.configuration';
+import { HttpException } from '@nestjs/common/exceptions/http.exception';
+import * as Sentry from '@sentry/node';
+import { beforeSend, normalizeLogMessage } from './sentry.configuration';
 
 describe('normalizeLogMessage', () => {
   it('keeps a constant message unchanged', () => {
@@ -42,5 +44,111 @@ describe('normalizeLogMessage', () => {
     const b = normalizeLogMessage('Failed to obtain Keycloak access token');
 
     expect(a).not.toBe(b);
+  });
+});
+
+describe('beforeSend', () => {
+  function event(
+    overrides: Partial<Sentry.ErrorEvent> = {},
+  ): Sentry.ErrorEvent {
+    return { type: undefined, ...overrides } as Sentry.ErrorEvent;
+  }
+
+  function hint(originalException?: unknown): Sentry.EventHint {
+    return { originalException } as Sentry.EventHint;
+  }
+
+  it('drops 4xx HttpExceptions, which are client errors rather than faults', () => {
+    const result = beforeSend(
+      event(),
+      hint(new HttpException('not found', 404)),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('reports 5xx HttpExceptions', () => {
+    const result = beforeSend(event(), hint(new HttpException('boom', 500)));
+
+    expect(result).not.toBeNull();
+  });
+
+  it('fingerprints HttpExceptions by status and route so unrelated CouchDB faults do not merge', () => {
+    const result = beforeSend(
+      event({ transaction: 'POST /:db/_bulk_docs' }),
+      hint(new HttpException('boom', 502)),
+    );
+
+    expect(result?.fingerprint).toEqual([
+      'HttpException',
+      '502',
+      'POST /:db/_bulk_docs',
+    ]);
+  });
+
+  it('separates the same status on different routes', () => {
+    const bulkDocs = beforeSend(
+      event({ transaction: 'POST /:db/_bulk_docs' }),
+      hint(new HttpException('boom', 500)),
+    );
+    const allDocs = beforeSend(
+      event({ transaction: 'GET /:db/_all_docs' }),
+      hint(new HttpException('boom', 500)),
+    );
+
+    expect(bulkDocs?.fingerprint).not.toEqual(allDocs?.fingerprint);
+  });
+
+  it('separates different statuses on the same route', () => {
+    const serverError = beforeSend(
+      event({ transaction: 'POST /:db/_bulk_docs' }),
+      hint(new HttpException('boom', 500)),
+    );
+    const badGateway = beforeSend(
+      event({ transaction: 'POST /:db/_bulk_docs' }),
+      hint(new HttpException('boom', 502)),
+    );
+
+    expect(serverError?.fingerprint).not.toEqual(badGateway?.fingerprint);
+  });
+
+  it('falls back to an explicit placeholder when no route is known', () => {
+    const result = beforeSend(event(), hint(new HttpException('boom', 500)));
+
+    expect(result?.fingerprint).toEqual([
+      'HttpException',
+      '500',
+      '<unknown route>',
+    ]);
+  });
+
+  it('fingerprints plain log messages using normalizeLogMessage', () => {
+    const message = 'Changes feed error (failure #1): timeout';
+    const result = beforeSend(event({ message }), hint());
+
+    expect(result?.fingerprint).toEqual([normalizeLogMessage(message)]);
+  });
+
+  it('prefers the status/route fingerprint over the normalized message for HttpExceptions', () => {
+    const result = beforeSend(
+      event({
+        message: 'Request failed: something dynamic',
+        transaction: 'GET /:db/_changes',
+      }),
+      hint(new HttpException('boom', 503)),
+    );
+
+    expect(result?.fingerprint).toEqual([
+      'HttpException',
+      '503',
+      'GET /:db/_changes',
+    ]);
+  });
+
+  it('passes through non-HttpException errors without a message unchanged', () => {
+    const result = beforeSend(event(), hint(new Error('kaboom')));
+
+    expect(result).not.toBeNull();
+    expect(result?.fingerprint).toBeUndefined();
   });
 });

--- a/src/sentry.configuration.spec.ts
+++ b/src/sentry.configuration.spec.ts
@@ -73,17 +73,51 @@ describe('beforeSend', () => {
     expect(result).not.toBeNull();
   });
 
-  it('fingerprints HttpExceptions by status and route so unrelated CouchDB faults do not merge', () => {
+  it('fingerprints operation-specific failures by status and route so unrelated CouchDB faults do not merge', () => {
     const result = beforeSend(
       event({ transaction: 'POST /:db/_bulk_docs' }),
-      hint(new HttpException('boom', 502)),
+      hint(new HttpException('boom', 500)),
     );
 
     expect(result?.fingerprint).toEqual([
       'HttpException',
-      '502',
+      '500',
       'POST /:db/_bulk_docs',
     ]);
+  });
+
+  it.each([
+    ['Bad Gateway', 502],
+    ['Service Unavailable', 503],
+    ['Gateway Timeout', 504],
+  ])(
+    'groups a generic %s by status alone, so one outage is not split per route',
+    (_name, status) => {
+      const bulkDocs = beforeSend(
+        event({ transaction: 'POST /:db/_bulk_docs' }),
+        hint(new HttpException('boom', status)),
+      );
+      const allDocs = beforeSend(
+        event({ transaction: 'GET /:db/_all_docs' }),
+        hint(new HttpException('boom', status)),
+      );
+
+      expect(bulkDocs?.fingerprint).toEqual(['HttpException', String(status)]);
+      expect(bulkDocs?.fingerprint).toEqual(allDocs?.fingerprint);
+    },
+  );
+
+  it('still separates different upstream-availability statuses from each other', () => {
+    const badGateway = beforeSend(
+      event({ transaction: 'POST /:db/_bulk_docs' }),
+      hint(new HttpException('boom', 502)),
+    );
+    const unavailable = beforeSend(
+      event({ transaction: 'POST /:db/_bulk_docs' }),
+      hint(new HttpException('boom', 503)),
+    );
+
+    expect(badGateway?.fingerprint).not.toEqual(unavailable?.fingerprint);
   });
 
   it('separates the same status on different routes', () => {
@@ -99,7 +133,7 @@ describe('beforeSend', () => {
     expect(bulkDocs?.fingerprint).not.toEqual(allDocs?.fingerprint);
   });
 
-  it('separates different statuses on the same route', () => {
+  it('never merges an operation-specific failure with an upstream outage on the same route', () => {
     const serverError = beforeSend(
       event({ transaction: 'POST /:db/_bulk_docs' }),
       hint(new HttpException('boom', 500)),
@@ -135,12 +169,12 @@ describe('beforeSend', () => {
         message: 'Request failed: something dynamic',
         transaction: 'GET /:db/_changes',
       }),
-      hint(new HttpException('boom', 503)),
+      hint(new HttpException('boom', 500)),
     );
 
     expect(result?.fingerprint).toEqual([
       'HttpException',
-      '503',
+      '500',
       'GET /:db/_changes',
     ]);
   });

--- a/src/sentry.configuration.spec.ts
+++ b/src/sentry.configuration.spec.ts
@@ -1,3 +1,7 @@
+import {
+  BadGatewayException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { HttpException } from '@nestjs/common/exceptions/http.exception';
 import * as Sentry from '@sentry/node';
 import { beforeSend, normalizeLogMessage } from './sentry.configuration';
@@ -184,5 +188,64 @@ describe('beforeSend', () => {
 
     expect(result).not.toBeNull();
     expect(result?.fingerprint).toBeUndefined();
+  });
+
+  describe('purpose-built exceptions on the same route', () => {
+    // PermissionCheckController's single `POST /permissions/check` route can
+    // throw a 502 BadGatewayException for two unrelated dependencies failing:
+    // Keycloak being unreachable, or the canonical entity document failing to
+    // load from CouchDB. Status+route alone can't tell those apart; the message
+    // — chosen by each call site, not by request data — has to.
+    const keycloakDown = () =>
+      new BadGatewayException('Upstream identity provider is unavailable');
+    const couchdbLoadFailed = () =>
+      new BadGatewayException('Failed to load target entity document');
+
+    it('separates unrelated dependency failures that share a status and route', () => {
+      const keycloak = beforeSend(
+        event({ transaction: 'POST /permissions/check' }),
+        hint(keycloakDown()),
+      );
+      const couchdb = beforeSend(
+        event({ transaction: 'POST /permissions/check' }),
+        hint(couchdbLoadFailed()),
+      );
+
+      expect(keycloak?.fingerprint).not.toEqual(couchdb?.fingerprint);
+    });
+
+    it('still groups repeats of the same dependency failure across requests', () => {
+      const first = beforeSend(
+        event({ transaction: 'POST /permissions/check' }),
+        hint(keycloakDown()),
+      );
+      const second = beforeSend(
+        event({ transaction: 'POST /permissions/check' }),
+        hint(keycloakDown()),
+      );
+
+      expect(first?.fingerprint).toEqual(second?.fingerprint);
+    });
+
+    it('normalizes an id interpolated into an otherwise-static message', () => {
+      const userA = beforeSend(
+        event(),
+        hint(
+          new InternalServerErrorException(
+            'Could not resolve entity name for user 5b8c774c-f2a9-4407-ad2e-a5325168b8e9',
+          ),
+        ),
+      );
+      const userB = beforeSend(
+        event(),
+        hint(
+          new InternalServerErrorException(
+            'Could not resolve entity name for user 1a2b3c4d-9999-4eee-8fff-abcdef012345',
+          ),
+        ),
+      );
+
+      expect(userA?.fingerprint).toEqual(userB?.fingerprint);
+    });
   });
 });

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -238,25 +238,30 @@ export function beforeSend(
   if (error instanceof HttpException) {
     const status = error.getStatus();
 
-    // Purpose-built exceptions (BadGatewayException, InternalServerErrorException,
-    // ...) are a different case from the bare, axios-mapped HttpException above:
-    // their message is chosen by the call site to describe *why* it failed, e.g.
-    // "Upstream identity provider is unavailable" (Keycloak) vs "Failed to load
-    // target entity document" (CouchDB) — two dependencies that can both throw
-    // BadGatewayException from the very same route. Status+route alone would
-    // conflate them into one issue; the message is what actually tells them
-    // apart, so prefer it here. Still normalize it: a call site may interpolate
-    // an id into an otherwise-static message (see normalizeLogMessage above).
-    event.fingerprint =
-      error.constructor === HttpException
-        ? UPSTREAM_AVAILABILITY_STATUSES.has(status)
-          ? ['HttpException', String(status)]
-          : [
-              'HttpException',
-              String(status),
-              event.transaction ?? UNKNOWN_ROUTE,
-            ]
-        : ['HttpException', String(status), normalizeLogMessage(error.message)];
+    if (error.constructor !== HttpException) {
+      // Purpose-built exceptions (BadGatewayException, InternalServerErrorException,
+      // ...) are a different case from the bare, axios-mapped HttpException above:
+      // their message is chosen by the call site to describe *why* it failed, e.g.
+      // "Upstream identity provider is unavailable" (Keycloak) vs "Failed to load
+      // target entity document" (CouchDB) — two dependencies that can both throw
+      // BadGatewayException from the very same route. Status+route alone would
+      // conflate them into one issue; the message is what actually tells them
+      // apart, so prefer it here. Still normalize it: a call site may interpolate
+      // an id into an otherwise-static message (see normalizeLogMessage above).
+      event.fingerprint = [
+        'HttpException',
+        String(status),
+        normalizeLogMessage(error.message),
+      ];
+    } else if (UPSTREAM_AVAILABILITY_STATUSES.has(status)) {
+      event.fingerprint = ['HttpException', String(status)];
+    } else {
+      event.fingerprint = [
+        'HttpException',
+        String(status),
+        event.transaction ?? UNKNOWN_ROUTE,
+      ];
+    }
   }
 
   return event;

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -237,9 +237,26 @@ export function beforeSend(
   // untouched, so response bodies and status codes are unchanged.
   if (error instanceof HttpException) {
     const status = error.getStatus();
-    event.fingerprint = UPSTREAM_AVAILABILITY_STATUSES.has(status)
-      ? ['HttpException', String(status)]
-      : ['HttpException', String(status), event.transaction ?? UNKNOWN_ROUTE];
+
+    // Purpose-built exceptions (BadGatewayException, InternalServerErrorException,
+    // ...) are a different case from the bare, axios-mapped HttpException above:
+    // their message is chosen by the call site to describe *why* it failed, e.g.
+    // "Upstream identity provider is unavailable" (Keycloak) vs "Failed to load
+    // target entity document" (CouchDB) — two dependencies that can both throw
+    // BadGatewayException from the very same route. Status+route alone would
+    // conflate them into one issue; the message is what actually tells them
+    // apart, so prefer it here. Still normalize it: a call site may interpolate
+    // an id into an otherwise-static message (see normalizeLogMessage above).
+    event.fingerprint =
+      error.constructor === HttpException
+        ? UPSTREAM_AVAILABILITY_STATUSES.has(status)
+          ? ['HttpException', String(status)]
+          : [
+              'HttpException',
+              String(status),
+              event.transaction ?? UNKNOWN_ROUTE,
+            ]
+        : ['HttpException', String(status), normalizeLogMessage(error.message)];
   }
 
   return event;

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -184,6 +184,24 @@ function initSentrySdk(sentryConfiguration: SentryConfiguration): void {
 const UNKNOWN_ROUTE = '<unknown route>';
 
 /**
+ * Statuses that describe the upstream (CouchDB, or a gateway in front of it)
+ * being unreachable or unhealthy, rather than describing the request that
+ * happened to hit it.
+ *
+ * These are grouped by status alone, without a route. A generic "Bad Gateway"
+ * means the same thing no matter which endpoint observed it, so including the
+ * route would split a single CouchDB outage into as many issues as there are
+ * endpoints in flight — exactly the fragmentation this fingerprinting exists to
+ * prevent. Operation-specific failures (500 and anything else) do differ by
+ * endpoint and keep their route.
+ */
+const UPSTREAM_AVAILABILITY_STATUSES: ReadonlySet<number> = new Set([
+  502, // Bad Gateway
+  503, // Service Unavailable
+  504, // Gateway Timeout
+]);
+
+/**
  * Decide whether an event is reported, and how it is grouped.
  *
  * Exported for testing — the grouping rules here determine whether a Sentry
@@ -211,17 +229,17 @@ export function beforeSend(
   // constant string "Http Exception". Sentry groups on that, so without an
   // explicit fingerprint every CouchDB fault — any status, any route — merges
   // into one opaque issue with no status and no route in its title. Fingerprint
-  // on status and route instead, so distinct faults stay distinct and each
-  // group is diagnosable on its own.
+  // on status, and on route where the route is what distinguishes one fault
+  // from another (see {@link UPSTREAM_AVAILABILITY_STATUSES}), so distinct
+  // faults stay distinct and each group is diagnosable on its own.
   //
   // This affects grouping only; the `HttpException` propagated to the client is
   // untouched, so response bodies and status codes are unchanged.
   if (error instanceof HttpException) {
-    event.fingerprint = [
-      'HttpException',
-      String(error.getStatus()),
-      event.transaction ?? UNKNOWN_ROUTE,
-    ];
+    const status = error.getStatus();
+    event.fingerprint = UPSTREAM_AVAILABILITY_STATUSES.has(status)
+      ? ['HttpException', String(status)]
+      : ['HttpException', String(status), event.transaction ?? UNKNOWN_ROUTE];
   }
 
   return event;

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -173,21 +173,56 @@ function initSentrySdk(sentryConfiguration: SentryConfiguration): void {
     // Set sampling rate for profiling - this is relative to tracesSampleRate
     profilesSampleRate: 1.0,
 
-    beforeSend: (event, hint) => {
-      const error = hint.originalException;
-      if (
-        error instanceof HttpException &&
-        error.getStatus() >= 400 &&
-        error.getStatus() < 500
-      ) {
-        return null;
-      }
-
-      if (event.message) {
-        event.fingerprint = [normalizeLogMessage(event.message)];
-      }
-
-      return event;
-    },
+    beforeSend,
   });
+}
+
+/**
+ * Route for an event when none can be determined, kept as an explicit constant
+ * so grouped events don't silently merge with events that do have a route.
+ */
+const UNKNOWN_ROUTE = '<unknown route>';
+
+/**
+ * Decide whether an event is reported, and how it is grouped.
+ *
+ * Exported for testing — the grouping rules here determine whether a Sentry
+ * issue is actionable, so they are worth asserting on directly.
+ */
+export function beforeSend(
+  event: Sentry.ErrorEvent,
+  hint: Sentry.EventHint,
+): Sentry.ErrorEvent | null {
+  const error = hint.originalException;
+  if (
+    error instanceof HttpException &&
+    error.getStatus() >= 400 &&
+    error.getStatus() < 500
+  ) {
+    return null;
+  }
+
+  if (event.message) {
+    event.fingerprint = [normalizeLogMessage(event.message)];
+  }
+
+  // CouchdbService maps every failed axios response to a bare `HttpException`
+  // (see `initMapAxiosErrorsToNestjsExceptions`), whose message renders as the
+  // constant string "Http Exception". Sentry groups on that, so without an
+  // explicit fingerprint every CouchDB fault — any status, any route — merges
+  // into one opaque issue with no status and no route in its title. Fingerprint
+  // on status and route instead, so distinct faults stay distinct and each
+  // group is diagnosable on its own.
+  //
+  // This affects grouping only; the `HttpException` propagated to the client is
+  // untouched, so response bodies and status codes are unchanged.
+  if (error instanceof HttpException) {
+    event.fingerprint = [
+      'HttpException',
+      String(error.getStatus()),
+      event.transaction ?? UNKNOWN_ROUTE,
+    ];
+  }
+
+  return event;
 }


### PR DESCRIPTION
Closes #293

## Problem

`CouchdbService.initMapAxiosErrorsToNestjsExceptions` (`src/couchdb/couchdb.service.ts:55`) maps every failed axios response to a bare `HttpException`:

```ts
const resultErr = err.response
  ? new HttpException(err.response.data, err.response.status)
  : err;
```

That exception's message renders as the constant string `"Http Exception"`. Sentry groups on it, so **every CouchDB fault — any status, any route — merges into a single issue whose title contains neither a status code nor a route.**

That issue is [REPLICATION-BACKEND-A7](https://aam-digital.sentry.io/issues/REPLICATION-BACKEND-A7): **828 occurrences / 18 users** lifetime, currently `escalating`. In the window this was found (2026-07-28 → 2026-07-29) it absorbed 51 events spanning `POST /app/_bulk_docs`, `GET /app/_all_docs`, `GET /app/_design/search_index` and three different `_local/*` replication checkpoints — with no way to tell from Sentry which fault was which, or even what status CouchDB returned.

Note the existing `beforeSend` already drops 4xx `HttpException`s, so what lands in A7 is CouchDB **5xx** responses — the ones most worth being able to distinguish.

## Change

Fingerprint `HttpException` events, splitting on whatever actually distinguishes one fault from another:

```ts
const status = error.getStatus();
event.fingerprint = UPSTREAM_AVAILABILITY_STATUSES.has(status)
  ? ['HttpException', String(status)]
  : ['HttpException', String(status), event.transaction ?? UNKNOWN_ROUTE];
```

- **Operation-specific failures** (500, and anything not listed below) group by **status + route**. These genuinely differ per endpoint.
- **Upstream-availability failures** — `502 Bad Gateway`, `503 Service Unavailable`, `504 Gateway Timeout` — group by **status alone**. These describe CouchDB (or a gateway in front of it) being unreachable, which is one condition regardless of which request observed it. Including the route would split a single outage into as many issues as there are endpoints in flight — the same fragmentation this PR exists to prevent, just on a different axis. Thanks to @sleidig for catching this in review.

`event.transaction` is the parameterised Nest route (e.g. `POST /:db/_bulk_docs`), not the raw URL, so document IDs don't fragment groups the other way.

This affects **Sentry grouping only**. The `HttpException` propagated to the client is untouched, so response bodies and status codes are unchanged — there is no API behaviour change.

`beforeSend` is extracted from the inline `Sentry.init` options and exported, because it had no test coverage and its rules decide whether an issue is actionable at all. The existing behaviours (dropping 4xx, grouping log messages via `normalizeLogMessage`) are preserved unchanged and now covered by tests.

## Verification

- Grouping tests cover both directions — under-splitting *and* over-splitting:
  - 4xx dropped; 5xx reported
  - 500 fingerprints by status + route; the same 500 on two different routes stays distinct
  - 502/503/504 on `POST /:db/_bulk_docs` and `GET /:db/_all_docs` produce an **identical** fingerprint
  - different upstream statuses still separate from each other (502 ≠ 503)
  - an operation-specific failure never merges with an upstream outage on the same route (500 ≠ 502)
  - unknown-route fallback; existing message grouping preserved; `HttpException` fingerprint takes precedence over the message; non-`HttpException` errors passed through untouched
- `npx jest` — full suite green: **275 tests / 32 suites**
- `npx nest build` — clean
- `npx prettier --check` — clean

## Open question

I drew the upstream-availability line at 502/503/504 and deliberately left **507 Insufficient Storage** out. It is arguably also route-independent — a full disk is a server-state condition, not a property of the request — but I have not observed CouchDB returning it here, so I would rather not encode a guess. Easy to add if reviewers think it belongs.

## Follow-up

Once this is deployed, the dev burst described in #293 should be re-examined: with a status and route attached it should be immediately clear whether it was one sustained CouchDB fault or several independent ones. Existing A7 events will stay in the old group; new events will split.