### PR TITLE
fix(logging): group log messages by normalized text instead of colon prefix

### DIFF
--- a/src/audit/audit.service.ts
+++ b/src/audit/audit.service.ts
@@ -159,10 +159,11 @@ export class DefaultAuditService extends AuditService {
       // best-effort: log but never fail the original write. Normalization must
       // itself never throw (JSON.stringify can throw on circular throwables).
       const reason = this.errorReason(err);
-      this.logger.error(
-        `Failed to write audit records for db '${db}': ${reason}`,
-        err instanceof Error ? err.stack : undefined,
-      );
+      this.logger.error('Failed to write audit records', {
+        db,
+        reason,
+        stack: err instanceof Error ? err.stack : undefined,
+      });
     }
   }
 

--- a/src/couchdb/document-changes.service.ts
+++ b/src/couchdb/document-changes.service.ts
@@ -129,9 +129,10 @@ export class DocumentChangesService implements OnModuleDestroy {
           }
         },
         error: (err) => {
-          this.logger.error(
-            `Changes feed for "${db}" terminated unexpectedly: ${this.formatError(err)}`,
-          );
+          this.logger.error('Changes feed terminated unexpectedly', {
+            db,
+            error: this.formatError(err),
+          });
         },
       });
 
@@ -178,6 +179,7 @@ export class DocumentChangesService implements OnModuleDestroy {
       backoff.justSaturated ||
       failureCount % DocumentChangesService.SATURATED_LOG_EVERY_N === 0
     ) {
+      // `message` is one of two constants, so this stays a stable grouping key
       this.logger.error(`SUSTAINED OUTAGE: ${message}`, logContext);
     }
   }

--- a/src/permissions/permission-check/permission-check.controller.ts
+++ b/src/permissions/permission-check/permission-check.controller.ts
@@ -187,10 +187,11 @@ export class PermissionCheckController {
     }
 
     // Unknown/unexpected error -> log and report per-user
-    this.logger.error(
-      `Failed to evaluate permissions for user ${userId}`,
-      error instanceof Error ? error.stack || error.message : String(error),
-    );
+    this.logger.error('Failed to evaluate permissions for user', {
+      userId,
+      error:
+        error instanceof Error ? error.stack || error.message : String(error),
+    });
     return [userId, { permitted: false, error: 'ERROR' }] as const;
   }
 
@@ -212,10 +213,11 @@ export class PermissionCheckController {
         throw new BadRequestException(`entityDoc not found: ${entityId}`);
       }
 
-      this.logger.error(
-        `Failed to load canonical entity document ${entityId}`,
-        error instanceof Error ? error.stack || error.message : String(error),
-      );
+      this.logger.error('Failed to load canonical entity document', {
+        entityId,
+        error:
+          error instanceof Error ? error.stack || error.message : String(error),
+      });
       throw new BadGatewayException('Failed to load target entity document');
     }
   }

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -630,6 +630,7 @@ describe('RulesService', () => {
     expect(freshService.getRulesForUser(undefined as any)).toEqual([]);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('[PERMISSIONS_BOOTSTRAP_MODE] BOOTSTRAP MODE'),
+      expect.objectContaining({ db: 'app' }),
     );
 
     warnSpy.mockRestore();
@@ -746,6 +747,7 @@ describe('RulesService', () => {
     expect(error).toBeInstanceOf(HttpException);
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('CRITICAL: gave up loading initial permissions'),
+      expect.objectContaining({ db: 'app' }),
     );
     // No permission config was ever loaded — getRulesForUser must deny all.
     expect(freshService.getRulesForUser(normalUser)).toEqual([]);

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -197,7 +197,8 @@ export class RulesService implements OnModuleInit {
     }
 
     this.logger.error(
-      `CRITICAL: gave up loading initial permissions from "${db}" after ${RulesService.INIT_MAX_TOTAL_MS}ms. Aborting startup.`,
+      'CRITICAL: gave up loading initial permissions. Aborting startup.',
+      { db, timeoutMs: RulesService.INIT_MAX_TOTAL_MS },
     );
     throw lastError instanceof Error
       ? lastError
@@ -217,12 +218,13 @@ export class RulesService implements OnModuleInit {
       this.setPermission(RulesService.bootstrapPermissions());
     }
     this.logger.warn(
-      `[PERMISSIONS_BOOTSTRAP_MODE] BOOTSTRAP MODE: no permission document "${Permission.DOC_ID}" found in "${db}". ` +
-        `Granting full access to admin_app users only until the real permission config is created. ` +
-        `All other users are denied. ` +
-        `Startup continued with bootstrap permissions. ` +
-        `If this instance is not in first-time setup, treat this as a possible misconfiguration ` +
-        `(check PERMISSION_DB, DATABASE_URL, and reverse proxy routing).`,
+      '[PERMISSIONS_BOOTSTRAP_MODE] BOOTSTRAP MODE: no permission document found. ' +
+        'Granting full access to admin_app users only until the real permission config is created. ' +
+        'All other users are denied. ' +
+        'Startup continued with bootstrap permissions. ' +
+        'If this instance is not in first-time setup, treat this as a possible misconfiguration ' +
+        '(check PERMISSION_DB, DATABASE_URL, and reverse proxy routing).',
+      { db, document: Permission.DOC_ID },
     );
   }
 
@@ -267,17 +269,21 @@ export class RulesService implements OnModuleInit {
                     1000 * 2 ** (retryCount - 1),
                     RulesService.INIT_MAX_DELAY_MS,
                   );
-                  this.logger.log(
-                    `Retrying permission document fetch for ${db} (attempt ${retryCount}).`,
-                    { retryDelayMs: delayMs },
-                  );
+                  this.logger.log('Retrying permission document fetch', {
+                    db,
+                    attempt: retryCount,
+                    retryDelayMs: delayMs,
+                  });
                   return timer(delayMs);
                 },
               }),
               catchError((error: unknown) => {
                 this.logger.warn(
-                  `Failed to fetch updated permission document for ${db} after retries; keeping previous in-memory permissions.`,
-                  error instanceof Error ? error.stack : String(error),
+                  'Failed to fetch updated permission document after retries; keeping previous in-memory permissions.',
+                  {
+                    db,
+                    error: error instanceof Error ? error.stack : String(error),
+                  },
                 );
                 return EMPTY;
               }),
@@ -295,7 +301,8 @@ export class RulesService implements OnModuleInit {
 
     if (!PermissionConfigValidator.isValidRulesConfig(newPermissions)) {
       this.logger.warn(
-        `Permissions change for ${db} did not contain valid data; keeping previous in-memory permissions.`,
+        'Permissions change did not contain valid data; keeping previous in-memory permissions.',
+        { db },
       );
       return;
     }
@@ -314,7 +321,8 @@ export class RulesService implements OnModuleInit {
    */
   private applyPermissionDeletion(db: string): void {
     this.logger.warn(
-      `[PERMISSIONS] Permission document "${Permission.DOC_ID}" was deleted in ${db}; failing closed to bootstrap permissions (admin_app only).`,
+      '[PERMISSIONS] Permission document was deleted; failing closed to bootstrap permissions (admin_app only).',
+      { db, document: Permission.DOC_ID },
     );
     const prevPermissions = this.permission;
     const bootstrap = RulesService.bootstrapPermissions();
@@ -348,8 +356,11 @@ export class RulesService implements OnModuleInit {
           })
           .catch((error: unknown) => {
             this.logger.error(
-              `Failed to clear local docs after permission update for ${db}`,
-              error instanceof Error ? error.stack : String(error),
+              'Failed to clear local docs after permission update',
+              {
+                db,
+                error: error instanceof Error ? error.stack : String(error),
+              },
             );
           }),
       1000,
@@ -380,10 +391,10 @@ export class RulesService implements OnModuleInit {
       // Belt-and-braces: this method must never throw, even if the merge
       // logic or the conflict re-fetch misbehaves; the next change event
       // triggers another attempt (self-healing).
-      this.logger.error(
-        `Failed to write managed default permissions to "${db}"`,
-        error instanceof Error ? error.stack : String(error),
-      );
+      this.logger.error('Failed to write managed default permissions', {
+        db,
+        error: error instanceof Error ? error.stack : String(error),
+      });
     }
   }
 
@@ -421,7 +432,8 @@ export class RulesService implements OnModuleInit {
         // warn only after the write persisted, so a failed or conflicting
         // attempt does not falsely claim rules were replaced
         this.logger.warn(
-          `Customized rule(s) carrying the "${SYSTEM_DEFAULT_MARKER}" marker were replaced in "${db}": ${JSON.stringify(dropped)}`,
+          'Customized rule(s) carrying the system-default marker were replaced',
+          { db, marker: SYSTEM_DEFAULT_MARKER, dropped },
         );
       }
       this.logger.log(
@@ -505,7 +517,9 @@ export class RulesService implements OnModuleInit {
 
       if (!has({ user }, name)) {
         // log instead of silent failure
-        this.logger.warn(`Variable ${name} is not defined for user ${user.id}`);
+        this.logger.warn('Rule variable is not defined for user', {
+          variable: name,
+        });
         return RulesService.USER_PROPERTY_UNDEFINED;
       }
 

--- a/src/permissions/user-identity/keycloak-user-admin.service.ts
+++ b/src/permissions/user-identity/keycloak-user-admin.service.ts
@@ -89,10 +89,9 @@ export class KeycloakUserAdminService extends UserAdminService {
         }),
       );
     } catch (error) {
-      this.logger.error(
-        `Failed to obtain Keycloak access token`,
-        error instanceof Error ? error.stack : String(error),
-      );
+      this.logger.error('Failed to obtain Keycloak access token', {
+        error: error instanceof Error ? error.stack : String(error),
+      });
       throw error;
     }
 
@@ -130,10 +129,10 @@ export class KeycloakUserAdminService extends UserAdminService {
       );
       return response.data;
     } catch (error) {
-      this.logger.warn(
-        `Failed to fetch Keycloak user ${userId}`,
-        error instanceof Error ? error.stack : String(error),
-      );
+      this.logger.warn('Failed to fetch Keycloak user', {
+        userId,
+        error: error instanceof Error ? error.stack : String(error),
+      });
       throw error;
     }
   }
@@ -155,10 +154,10 @@ export class KeycloakUserAdminService extends UserAdminService {
       );
       return (response.data ?? []).map((role) => role.name).filter(Boolean);
     } catch (error) {
-      this.logger.warn(
-        `Failed to fetch roles for Keycloak user ${userId}`,
-        error instanceof Error ? error.stack : String(error),
-      );
+      this.logger.warn('Failed to fetch roles for Keycloak user', {
+        userId,
+        error: error instanceof Error ? error.stack : String(error),
+      });
       throw error;
     }
   }

--- a/src/permissions/user-identity/user-identity.service.ts
+++ b/src/permissions/user-identity/user-identity.service.ts
@@ -42,10 +42,10 @@ export class UserIdentityService {
     const userEntity = await firstValueFrom(
       this.couchdbService.get('app', account.name),
     ).catch((error) => {
-      this.logger.warn(
-        `Failed to fetch projects for user entity ${account.name}`,
-        error?.stack || error,
-      );
+      this.logger.warn('Failed to fetch projects for user entity', {
+        userEntity: account.name,
+        error: error?.stack || String(error),
+      });
       return undefined;
     });
     const projects = Array.isArray(userEntity?.projects)
@@ -93,8 +93,8 @@ export class UserIdentityService {
       },
       error: (err) => {
         this.logger.error(
-          `Entity changes feed terminated unexpectedly; cache invalidation disabled`,
-          err?.stack || String(err),
+          'Entity changes feed terminated unexpectedly; cache invalidation disabled',
+          { error: err?.stack || String(err) },
         );
       },
     });

--- a/src/sentry.configuration.spec.ts
+++ b/src/sentry.configuration.spec.ts
@@ -1,0 +1,46 @@
+import { normalizeLogMessage } from './sentry.configuration';
+
+describe('normalizeLogMessage', () => {
+  it('keeps a constant message unchanged', () => {
+    const message = 'Failed to fetch Keycloak user';
+
+    expect(normalizeLogMessage(message)).toBe(message);
+  });
+
+  it('groups messages that interpolate a user id', () => {
+    const a = normalizeLogMessage(
+      'Failed to fetch Keycloak user 5b8c774c-f2a9-4407-ad2e-a5325168b8e9',
+    );
+    const b = normalizeLogMessage(
+      'Failed to fetch Keycloak user 1a2b3c4d-9999-4eee-8fff-abcdef012345',
+    );
+
+    expect(a).toBe(b);
+  });
+
+  it('groups messages that differ only in a counter', () => {
+    // the earlier prefix-before-first-colon heuristic split these, because the
+    // counter appears before the colon
+    const a = normalizeLogMessage('Changes feed error (failure #1): timeout');
+    const b = normalizeLogMessage('Changes feed error (failure #2): timeout');
+
+    expect(a).toBe(b);
+  });
+
+  it('groups messages that differ only in a host or url', () => {
+    const a = normalizeLogMessage('connect ECONNREFUSED 192.168.64.8:5984');
+    const b = normalizeLogMessage('connect ECONNREFUSED 172.20.0.4:5984');
+    const c = normalizeLogMessage('request to https://example.org/db failed');
+    const d = normalizeLogMessage('request to https://other.example/db failed');
+
+    expect(a).toBe(b);
+    expect(c).toBe(d);
+  });
+
+  it('keeps genuinely different messages apart', () => {
+    const a = normalizeLogMessage('Failed to fetch Keycloak user');
+    const b = normalizeLogMessage('Failed to obtain Keycloak access token');
+
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/sentry.configuration.ts
+++ b/src/sentry.configuration.ts
@@ -121,6 +121,42 @@ class SentryFilter extends BaseExceptionFilter {
   }
 }
 
+/**
+ * Data that varies between occurrences of the same log message and therefore
+ * has to be masked before the message can be used as a grouping key.
+ * Order matters: the more specific patterns have to run before the plain number.
+ */
+const VOLATILE_MESSAGE_PATTERNS: [RegExp, string][] = [
+  [/https?:\/\/\S+/gi, '<url>'],
+  [
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+    '<uuid>',
+  ],
+  [/\b\d{1,3}(?:\.\d{1,3}){3}\b/g, '<ip>'],
+  [/\d+/g, '<n>'],
+];
+
+/**
+ * Build a stable grouping key for a log message.
+ *
+ * Callers are expected to keep message strings constant and pass variable
+ * details as an object parameter (see {@link SentryLogger}), but a message that
+ * still interpolates an id, host or counter must not fragment into one issue
+ * per value - so those are masked here as a safety net.
+ *
+ * Note this replaces an earlier heuristic that used the message prefix up to
+ * the first colon: it silently did nothing for messages without a colon (one
+ * issue per user id), and split on variable data that appeared *before* the
+ * colon (one issue per retry counter).
+ */
+export function normalizeLogMessage(message: string): string {
+  return VOLATILE_MESSAGE_PATTERNS.reduce(
+    (normalized, [pattern, placeholder]) =>
+      normalized.replace(pattern, placeholder),
+    message,
+  );
+}
+
 function initSentrySdk(sentryConfiguration: SentryConfiguration): void {
   Sentry.init({
     release: version,
@@ -147,13 +183,8 @@ function initSentrySdk(sentryConfiguration: SentryConfiguration): void {
         return null;
       }
 
-      // Group log messages by their static prefix (before the first colon)
-      // so dynamic details don't fragment issues.
       if (event.message) {
-        const prefixEnd = event.message.indexOf(':');
-        if (prefixEnd > 0) {
-          event.fingerprint = [event.message.substring(0, prefixEnd)];
-        }
+        event.fingerprint = [normalizeLogMessage(event.message)];
       }
 
       return event;


### PR DESCRIPTION
Companion to Aam-Digital/ndb-core#4210, which does the equivalent for the frontend.

## Problem

The exception side here is healthy — 2 error types, 2 issues over the last 30 days. The
*message* side is not: several log messages interpolate variable data, and monitoring groups
messages by their text, so one problem becomes one issue per value.

- `Failed to fetch Keycloak user ${userId}` → one issue per user id
  ([AX](https://aam-digital.sentry.io/issues/REPLICATION-BACKEND-AX), 44 events)
- `Failed to fetch projects for user entity ${account.name}` → already three separate issues
  (AY, B2, BA), each titled with a real user entity name
- `Variable ${name} is not defined for user ${user.id}` →
  [AT](https://aam-digital.sentry.io/issues/REPLICATION-BACKEND-AT), 72 events
- `Changes feed error for "${db}" (failure #${n}): …` → one issue per failure counter
  (9F, 9G, 9H, 9J)

`SentryLogger` already supports the fix — it collects object params into `extra.details`
specifically so callers can "pass a constant message (for stable Sentry grouping) and still
attach per-event details", and a few call sites already do. Most just don't.

The `beforeSend` fallback did not cover the gap. Grouping by the message prefix up to the first
colon silently did nothing when a message had no colon (that is exactly the per-user-id case),
and split on variable data that appeared *before* the colon (the per-counter case).

## Changes

- `beforeSend` masks urls, UUIDs, IPs and numbers anywhere in the message before using it as a
  fingerprint, so grouping no longer depends on where a colon happens to fall.
- Call sites move interpolated ids, database names, entity names and counters into the context
  object, where they show up as structured `extra` data instead of in the issue title.
- Messages that concatenate *constants* are deliberately left as they are — they already group
  stably, and the distinction between them (e.g. an authentication failure vs a request failure
  in the same outage handler) is worth keeping as separate issues.

## Not included

The historical `_changes … took Nms (…)` cluster in the issue list — 11 single-event issues plus
3 more for `_changes request slow:` — looks like the same bug but is **already fixed**. Those
events are all from 2026-05-05 to 05-10 and predate `d611091` and `196b0ae`. They are stale
issues that were never archived, not live breakage.

Startup logging in `sentry.configuration.ts` itself is also untouched: it runs before
`Sentry.init`, so it cannot reach monitoring and its grouping is irrelevant.

## After deploying

Changing a fingerprint does not re-group events already in Sentry. The existing per-value issues
stop receiving events and the merged versions appear as new unresolved issues; the old ones can
be archived once this is released.

## Testing

- New `sentry.configuration.spec.ts` covers the normalization: constant messages unchanged,
  per-user-id and per-counter variants collapsing, urls and hosts masked, and genuinely
  different messages staying apart.
- Two existing `rules.service` assertions updated for the moved context data.
- Full suite: 241 passed, 31 suites. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved error and warning logs with consistent structured details for easier diagnosis.
  * Enhanced monitoring to group similar errors more accurately by normalizing changing values such as URLs, IDs, IP addresses, and numbers.
* **Tests**
  * Added coverage validating log normalization and improved monitoring event grouping.
  * Updated logging tests to verify database context is retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->