### PR TITLE
fix(deps): pin axios below 1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "rxjs": "^7.8.2",
     "stream-json": "^1.9.1"
   },
+  "overrides": {
+    "axios": "1.18.0"
+  },
   "devDependencies": {
     "@nestjs/schematics": "^11.1.0",
     "@nestjs/testing": "^11.1.28",


### PR DESCRIPTION
Pins `axios` to 1.18.0 so dependency updates can refresh the lockfile without breaking the build. Unblocks #297.

### Why

axios 1.19.0 (via axios/axios#11081) added to **both** `index.d.ts` and `index.d.cts`:

```ts
declare const axiosResponseDefault: unique symbol;
type AxiosResponseDefault = typeof axiosResponseDefault;
```

Two declaration sites mean two distinct symbol identities. axios publishes dual types (`types: { default: './index.d.ts', require: './index.d.cts' }`), and our CommonJS build resolves the `require` condition while `@nestjs/axios` resolves the other, so the two `AxiosResponseResult` types come out unrelated and `permission.module.ts:29` stops compiling:

```
error TS2345: Argument of type 'AxiosInstance' is not assignable to parameter of type 'AxiosInstance'.
  Two different types with this name exist, but they are unrelated.
```

That is what #297 hits when lock maintenance moves axios 1.18.0 to 1.19.0. Its e2e failures are the same cause, since those suites compile `app.module`.

### Why not just wait for the upstream fix

There is an open upstream issue (axios/axios#11116) with a fix in axios/axios#11117, but that PR only moves the symbol onto the `AxiosStatic` interface, so each declaration file still declares its own and the cross-file mismatch survives. I applied it to the installed declarations and our error is unchanged. It fixes their declaration-emit symptom (TS2527), not our assignability one, so waiting for it would not unblock us.

The pin should be lifted once axios ships a version where the marker is shared across both declaration files.

### Verification

| check | result |
| --- | --- |
| `npm ci` with the override | passes, resolves axios 1.18.0 |
| full lockfile regeneration with the override | resolves axios 1.18.0, so #297 stays green after a rebase |
| unit suite | 32 suites, 278 tests passing |

No lockfile change in this PR: master already resolves 1.18.0, so the override is a forward guard that takes effect the next time anything tries to resolve 1.19.

### Manual Testing Steps

No behaviour change, this only constrains dependency resolution. Worth confirming CI is green here, then rebasing #297 and confirming it goes green too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a transitive networking dependency to a fixed version for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->