### PR TITLE
chore(deps): enable Renovate for Dockerfile base image updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     "group:allNonMajor",
     ":maintainLockFilesMonthly"
   ],
-  "enabledManagers": ["npm"],
+  "enabledManagers": ["npm", "dockerfile"],
   "timezone": "Etc/UTC",
   "schedule": ["after 00:00 and before 09:00 on Monday"],
   "dependencyDashboard": false,
@@ -31,6 +31,12 @@
       "matchDepTypes": ["dependencies", "devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "weekly-non-major-updates",
+      "automerge": false
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "docker-base-image",
       "automerge": false
     }
   ]


### PR DESCRIPTION
## Summary
- Adds `dockerfile` to `enabledManagers` so Renovate tracks the `node:24-alpine` base image (both build stages) in the Dockerfile — previously only npm deps were covered.
- Adds a `docker-base-image` package rule grouping minor/patch base-image bumps into their own PR, separate from the npm `weekly-non-major-updates` group. Major bumps already flow through the existing unrestricted major-update rule (draft PR).

## Test plan
- [ ] Confirm Renovate picks up the Dockerfile on next run (dependency dashboard / PR appears if an update is available)