### PR TITLE
fix(logging): only warn about _changes requests that are actually slow

### DIFF
--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -49,9 +49,15 @@ const MAX_PROCESSING_TIME_MS = 8000;
  */
 const MAX_INTERNAL_LIMIT = 1000;
 
-/** Requests exceeding one of these thresholds are logged as a warning. */
+/**
+ * Requests taking longer than this are logged as a warning.
+ *
+ * Deliberately based on duration only: a high number of CouchDB round-trips is
+ * normal for users whose permissions filter out most changes, and says nothing
+ * about how long the request actually took. Those requests are still logged
+ * (with their `iterations` count) on the debug level below.
+ */
 const SLOW_REQUEST_DURATION_MS = 2000;
-const SLOW_REQUEST_ITERATIONS = 2;
 
 /**
  * A "clean" deletion tombstone holds nothing but `_id`, `_rev` and `_deleted`.
@@ -353,10 +359,7 @@ export class ChangesController {
       limit: params?.limit ?? 'none',
       pending: summary.pending,
     };
-    if (
-      duration > SLOW_REQUEST_DURATION_MS ||
-      summary.iterations > SLOW_REQUEST_ITERATIONS
-    ) {
+    if (duration > SLOW_REQUEST_DURATION_MS) {
       this.logger.warn('_changes request slow', details);
     } else {
       this.logger.debug('_changes request completed', details);


### PR DESCRIPTION
Re-tunes the `_changes request slow` warning, which is the source of Sentry issue [REPLICATION-BACKEND-9D](https://aam-digital.sentry.io/issues/REPLICATION-BACKEND-9D) (8.5k events, 45 users, currently archived).

## The problem

The warning condition was an OR over two thresholds:

```ts
if (duration > SLOW_REQUEST_DURATION_MS || summary.iterations > SLOW_REQUEST_ITERATIONS)
```

Essentially every event comes in through the **iterations** clause, not the duration one. Sampled events from the issue itself:

| duration | iterations | fetched | filtered out | permitted |
|---|---|---|---|---|
| 147 ms | 3 | 685 | 564 | 100 |
| 130 ms | 4 | 1195 | 1056 | 100 |
| 305 ms | 4 | 1660 | 1441 | 100 |
| 444 ms | 14 | 1020 | 920 | 100 |

All are sub-second and all filled the client's requested limit. A high round-trip count is exactly what the loop is designed to do for users whose permissions filter out most changes — it is a measure of permission selectivity, not of latency. Labelling these "slow" is wrong, and it fires in bursts during a restricted user's initial sync.

## Why the duration threshold stays at 2 s

Measured over 14 days on the `GET /:db/_changes` transaction: **p50 18.8 ms · p95 118 ms · p99 235 ms**, with only 150 of 615,600 transactions (0.024%) above 2 s. The bar is well clear of normal traffic while still catching real stalls — and those exist (max observed 180 s), since the `MAX_PROCESSING_TIME_MS` budget is only evaluated between round-trips, so a single slow CouchDB call or a back-pressured write can overrun it. Lowering the threshold would flood Sentry; raising it would hide the genuine outliers.

## What changes

- Drop the `iterations > 2` clause and the now-unused `SLOW_REQUEST_ITERATIONS` constant.
- Document why the remaining threshold is duration-only.

**No diagnostics are lost.** The `else` branch already logs the identical `details` object — `iterations` included — at debug level, and `debug` is part of the default NestJS log levels with no override configured. These requests are demoted from `warn` to `debug`, so they stay in the container logs and simply stop creating Sentry events (`SentryLogger` only mirrors `error` and `warn`).

**Note for reviewers:** the log message string is unchanged, so the Sentry group stays the same. `Fixes REPLICATION-BACKEND-9D` resolves the issue on merge, which means the first genuine >2 s request after release will reopen it and notify as a *regression*. That is the intended signal now (0.02% of traffic), it will just look like a regression the first time.

## Verification

`npm run build`, `npx eslint`, `prettier --check` and `npx jest` (32 suites, 279 tests) all pass.

## Follow-up spotted, not addressed here

The 14-iteration sample fetched only ~1,020 docs across 14 round-trips (~73 each) despite `MAX_INTERNAL_LIMIT` of 1000: `internalLimit` is derived from the *remaining* limit, so batch size collapses as the response fills (2 remaining ⇒ asking CouchDB for 10 rows). Cheap in wall-clock terms, but a floor on `internalLimit` would flatten the tail. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)