### PR TITLE
feat: pagination works correctly with filtered docs due to permissions

### DIFF
--- a/src/common/json-array-response-stream.ts
+++ b/src/common/json-array-response-stream.ts
@@ -1,0 +1,125 @@
+import { Response } from 'express';
+
+/**
+ * Streams a JSON response whose primary payload is one incrementally-written
+ * array field. The response envelope is opened lazily — only after the first
+ * successful upstream batch — so that errors raised before any data is ready
+ * still produce a proper HTTP error status instead of a truncated stream.
+ *
+ * Subclasses provide the array-field name via the constructor and expose
+ * domain-specific `write*` / `finish` methods that delegate to
+ * {@link writeItems} and {@link closeWith}.
+ */
+export abstract class JsonArrayResponseStream {
+  protected written = 0;
+  private opened = false;
+
+  protected constructor(
+    private readonly res: Response,
+    private readonly openingChunk: string,
+  ) {}
+
+  /** Whether the client has disconnected. */
+  get isClosed(): boolean {
+    return this.res.destroyed;
+  }
+
+  /** Number of docs written to the response so far. */
+  get docsWritten(): number {
+    return this.written;
+  }
+
+  /**
+   * Serialize and stream one batch of items into the array, opening the
+   * envelope on the first call. Flushes after each batch so compression
+   * middleware does not buffer the data until the response ends.
+   */
+  protected async writeItems<T>(
+    items: T[],
+    serialize: (item: T) => unknown,
+  ): Promise<void> {
+    await this.open();
+    for (const item of items) {
+      await this.writeChunk(
+        (this.written > 0 ? ',' : '') + JSON.stringify(serialize(item)),
+      );
+      this.written++;
+    }
+    this.flush();
+  }
+
+  /**
+   * Close the array, append the envelope tail and end the response.
+   * Ensures the envelope is opened even when no items were written.
+   */
+  protected async closeWith(closingChunk: string): Promise<void> {
+    await this.open();
+    await this.writeChunk(closingChunk);
+    this.res.end();
+  }
+
+  /**
+   * Send the response headers and open the JSON envelope (idempotent).
+   *
+   * Deliberately called only after the first upstream batch succeeds, so that
+   * upstream errors (e.g. unknown db) still yield a proper error status instead
+   * of a truncated stream.
+   */
+  private async open(): Promise<void> {
+    if (this.opened) return;
+    this.opened = true;
+    this.res.status(200);
+    this.res.setHeader('content-type', 'application/json');
+    await this.writeChunk(this.openingChunk);
+  }
+
+  /**
+   * Hand the buffered bytes to the client right away.
+   *
+   * Without this the compression middleware keeps a batch in its gzip buffer
+   * until enough data has accumulated, so nothing reaches the client until the
+   * response ends and the incremental writing above has no effect for the
+   * (compressing) clients that actually sync.
+   */
+  private flush(): void {
+    (this.res as Response & { flush?: () => void }).flush?.();
+  }
+
+  /**
+   * Write a chunk to the response, awaiting the drain event when the
+   * client cannot keep up (backpressure).
+   */
+  private writeChunk(chunk: string): Promise<void> {
+    const res = this.res;
+    return new Promise((resolve, reject) => {
+      if (res.destroyed) {
+        reject(new Error('client disconnected'));
+        return;
+      }
+      if (res.write(chunk)) {
+        resolve();
+        return;
+      }
+      const cleanup = () => {
+        res.off('drain', onDrain);
+        res.off('close', onFailure);
+        res.off('error', onFailure);
+      };
+      const onDrain = () => {
+        cleanup();
+        resolve();
+      };
+      // socket error or close while back-pressured: settle the promise so the
+      // request handler never hangs (which would leak a CouchDB keep-alive
+      // socket). 'error' is required — without it a socket error that does not
+      // also emit 'close' would leave this promise pending forever.
+      const onFailure = () => {
+        cleanup();
+        reject(new Error('client disconnected'));
+      };
+      res.once('drain', onDrain);
+      res.once('close', onFailure);
+      res.once('error', onFailure);
+    });
+  }
+}

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Readable, Writable } from 'stream';
 import { BulkDocEndpointsController } from './bulk-doc-endpoints.controller';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 import { BulkDocumentService } from './bulk-document.service';
 import { BulkGetResponse, BulkGetResult } from './couchdb-dtos/bulk-get.dto';
 import { AllDocsResponse } from './couchdb-dtos/all-docs.dto';
@@ -172,6 +172,77 @@ describe('BulkDocEndpointsController', () => {
       request,
     );
     expect(body()).toEqual({ docs: [{ _id: 'Report:1' }], bookmark: 'abc' });
+  });
+
+  it('should use the buffered path and filter docs when _find body has a limit', async () => {
+    jest.spyOn(mockCouchDBService, 'post').mockReturnValue(
+      of({
+        docs: [{ _id: 'Report:1' }, { _id: 'Secret:1' }],
+        bookmark: 'bm1',
+      }),
+    );
+    jest
+      .spyOn(documentFilter, 'findDocFilter')
+      .mockReturnValue((doc) => doc._id === 'Report:1');
+    const { res, body } = createMockResponse();
+
+    await controller.find('db', { selector: {}, limit: 10 }, user, res);
+
+    expect(mockCouchDBService.post).toHaveBeenCalledWith(
+      'db',
+      '_find',
+      expect.objectContaining({ limit: 50 }), // 10 * FIND_LIMIT_MULTIPLIER
+    );
+    expect(body()).toEqual({ docs: [{ _id: 'Report:1' }], bookmark: 'bm1' });
+  });
+
+  it('should iterate _find with bookmark when filtered results are below the limit', async () => {
+    // limit=5 → internalLimit = 5*5 = 25
+    // batch1: exactly 25 forbidden docs → loop continues (25 >= 25) with bookmark
+    // batch2: 5 permitted docs, fewer than 25 → loop stops
+    const batch1 = {
+      docs: Array.from({ length: 25 }, (_, i) => ({ _id: `Forbidden:${i}` })),
+      bookmark: 'bm1',
+    };
+    const batch2 = {
+      docs: Array.from({ length: 5 }, (_, i) => ({ _id: `Permitted:${i}` })),
+      bookmark: 'bm2',
+    };
+    jest
+      .spyOn(mockCouchDBService, 'post')
+      .mockReturnValueOnce(of(batch1))
+      .mockReturnValueOnce(of(batch2));
+    jest
+      .spyOn(documentFilter, 'findDocFilter')
+      .mockReturnValue((doc) => !!doc._id?.startsWith('Permitted'));
+    const { res, body } = createMockResponse();
+
+    await controller.find('db', { selector: {}, limit: 5 }, user, res);
+
+    expect(mockCouchDBService.post).toHaveBeenCalledTimes(2);
+    expect(mockCouchDBService.post).toHaveBeenNthCalledWith(
+      2,
+      'db',
+      '_find',
+      expect.objectContaining({ bookmark: 'bm1' }),
+    );
+    const result = body();
+    expect(result.docs).toHaveLength(5);
+    expect(result.bookmark).toBe('bm2');
+  });
+
+  it('should stop iterating _find when CouchDB returns fewer docs than requested', async () => {
+    jest.spyOn(mockCouchDBService, 'post').mockReturnValue(
+      of({ docs: [{ _id: 'Report:1' }], bookmark: 'bm1' }),
+    );
+    jest.spyOn(documentFilter, 'findDocFilter').mockReturnValue(() => false);
+    const { res, body } = createMockResponse();
+
+    await controller.find('db', { selector: {}, limit: 10 }, user, res);
+
+    // Only one call — CouchDB returned 1 < 50 (internal limit), so no more pages
+    expect(mockCouchDBService.post).toHaveBeenCalledTimes(1);
+    expect(body()).toEqual({ docs: [], bookmark: 'bm1' });
   });
 
   it('should abort the response if the upstream stream fails mid-transfer', async () => {

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
@@ -193,7 +193,7 @@ describe('BulkDocEndpointsController', () => {
       '_find',
       expect.objectContaining({ limit: 50 }), // 10 * FIND_LIMIT_MULTIPLIER
     );
-    expect(body()).toEqual({ docs: [{ _id: 'Report:1' }], bookmark: 'bm1' });
+    expect(body()).toEqual({ docs: [{ _id: 'Report:1' }] });
   });
 
   it('should iterate _find with bookmark when filtered results are below the limit', async () => {
@@ -228,13 +228,12 @@ describe('BulkDocEndpointsController', () => {
     );
     const result = body();
     expect(result.docs).toHaveLength(5);
-    expect(result.bookmark).toBe('bm2');
   });
 
   it('should stop iterating _find when CouchDB returns fewer docs than requested', async () => {
-    jest.spyOn(mockCouchDBService, 'post').mockReturnValue(
-      of({ docs: [{ _id: 'Report:1' }], bookmark: 'bm1' }),
-    );
+    jest
+      .spyOn(mockCouchDBService, 'post')
+      .mockReturnValue(of({ docs: [{ _id: 'Report:1' }], bookmark: 'bm1' }));
     jest.spyOn(documentFilter, 'findDocFilter').mockReturnValue(() => false);
     const { res, body } = createMockResponse();
 
@@ -242,7 +241,7 @@ describe('BulkDocEndpointsController', () => {
 
     // Only one call — CouchDB returned 1 < 50 (internal limit), so no more pages
     expect(mockCouchDBService.post).toHaveBeenCalledTimes(1);
-    expect(body()).toEqual({ docs: [], bookmark: 'bm1' });
+    expect(body()).toEqual({ docs: [] });
   });
 
   it('should abort the response if the upstream stream fails mid-transfer', async () => {

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
@@ -13,7 +13,8 @@ import { ApiOperation } from '@nestjs/swagger';
 import { Response } from 'express';
 import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
-import { from, Observable } from 'rxjs';
+import { firstValueFrom, from, Observable } from 'rxjs';
+import { JsonArrayResponseStream } from '../../../common/json-array-response-stream';
 import { CombinedAuthGuard } from '../../../auth/guards/combined-auth/combined-auth.guard';
 import { User } from '../../../auth/user.decorator';
 import { ClientDisconnectedError } from '../../../common/client-disconnected.error';
@@ -28,9 +29,41 @@ import { AllDocsRequest } from './couchdb-dtos/all-docs.dto';
 import {
   BulkDocsRequest,
   BulkDocsResponse,
+  DatabaseDocument,
+  FindResponse,
 } from './couchdb-dtos/bulk-docs.dto';
 import { BulkGetRequest } from './couchdb-dtos/bulk-get.dto';
 import { OnlyAuthenticated } from '../../../auth/only-authenticated.decorator';
+import {
+  INTERNAL_LIMIT_MULTIPLIER,
+  MAX_INTERNAL_LIMIT,
+} from '../changes/changes.controller';
+
+/**
+ * Streams a `_find` response to the client as JSON: permitted docs are sent as
+ * soon as each internal CouchDB batch is filtered, instead of accumulating
+ * everything in memory first. The `bookmark` envelope field is appended once the
+ * iteration finishes.
+ *
+ * The envelope is opened lazily — after the first CouchDB batch succeeds — so
+ * that upstream errors (e.g. unknown database) still yield a proper HTTP error
+ * status rather than a truncated stream.
+ */
+class FindResponseStream extends JsonArrayResponseStream {
+  constructor(res: Response) {
+    super(res, '{"docs":[');
+  }
+
+  /** Write one batch of permitted docs, opening the envelope if needed. */
+  async writeDocs(docs: DatabaseDocument[]): Promise<void> {
+    await this.writeItems(docs, (doc) => doc);
+  }
+
+  /** Append the bookmark envelope field and end the response. */
+  async finish(bookmark: string): Promise<void> {
+    await this.closeWith(`],"bookmark":${JSON.stringify(bookmark)}}`);
+  }
+}
 
 /**
  * Handle endpoints for the CouchDB replication process and bulk actions
@@ -97,14 +130,78 @@ export class BulkDocEndpointsController {
     @User() user: UserInfo,
     @Res() res: Response,
   ): Promise<void> {
-    const source = await this.couchdbService.postStream(db, '_find', body);
     const isPermitted = this.bulkDocumentService.findDocFilter(user);
-    await this.streamFiltered(
-      source,
-      'docs',
-      (doc) => (isPermitted(doc) ? doc : undefined),
-      res,
-    );
+    const findBody = body as { limit?: number; [key: string]: unknown };
+
+    if (findBody.limit === undefined) {
+      const source = await this.couchdbService.postStream(db, '_find', body);
+      await this.streamFiltered(
+        source,
+        'docs',
+        (doc) => (isPermitted(doc) ? doc : undefined),
+        res,
+      );
+      return;
+    }
+
+    const stream = new FindResponseStream(res);
+    try {
+      const bookmark = await this.streamPermittedFindDocs(
+        db,
+        findBody,
+        findBody.limit,
+        isPermitted,
+        stream,
+      );
+      await stream.finish(bookmark);
+    } catch (error) {
+      if (!res.headersSent) throw error;
+      this.logger.warn('aborting streamed _find response after error', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.destroy();
+    }
+  }
+
+  /**
+   * Iteratively fetch from `_find` with an inflated limit, filter by permission,
+   * and stream each permitted batch to the client. Uses the CouchDB `bookmark`
+   * to continue between rounds. Returns the final bookmark for the envelope.
+   */
+  private async streamPermittedFindDocs(
+    db: string,
+    body: { limit?: number; bookmark?: string; [key: string]: unknown },
+    requestedLimit: number,
+    isPermitted: (doc: DatabaseDocument) => boolean,
+    stream: FindResponseStream,
+  ): Promise<string> {
+    let bookmark: string | undefined = body.bookmark;
+
+    while (stream.docsWritten < requestedLimit && !stream.isClosed) {
+      const remaining = requestedLimit - stream.docsWritten;
+      const internalLimit = Math.min(
+        remaining * INTERNAL_LIMIT_MULTIPLIER,
+        MAX_INTERNAL_LIMIT,
+      );
+
+      const response = await firstValueFrom(
+        this.couchdbService.post<FindResponse>(db, '_find', {
+          ...body,
+          limit: internalLimit,
+          bookmark,
+        }),
+      );
+
+      const permitted = response.docs.filter(isPermitted).slice(0, remaining);
+      await stream.writeDocs(permitted);
+
+      bookmark = response.bookmark;
+
+      if (response.docs.length < internalLimit) break;
+      if (!response.bookmark) break;
+    }
+
+    return bookmark ?? '';
   }
 
   /**

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
@@ -42,8 +42,7 @@ import {
 /**
  * Streams a `_find` response to the client as JSON: permitted docs are sent as
  * soon as each internal CouchDB batch is filtered, instead of accumulating
- * everything in memory first. The `bookmark` envelope field is appended once the
- * iteration finishes.
+ * everything in memory first.
  *
  * The envelope is opened lazily — after the first CouchDB batch succeeds — so
  * that upstream errors (e.g. unknown database) still yield a proper HTTP error
@@ -59,7 +58,7 @@ class FindResponseStream extends JsonArrayResponseStream {
     await this.writeItems(docs, (doc) => doc);
   }
 
-  /** Append the bookmark envelope field and end the response. */
+  /** End the response. */
   async finish(): Promise<void> {
     await this.closeWith(`]}`);
   }
@@ -166,7 +165,7 @@ export class BulkDocEndpointsController {
   /**
    * Iteratively fetch from `_find` with an inflated limit, filter by permission,
    * and stream each permitted batch to the client. Uses the CouchDB `bookmark`
-   * to continue between rounds. Returns the final bookmark for the envelope.
+   * to continue between rounds.
    */
   private async streamPermittedFindDocs(
     db: string,

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
@@ -60,8 +60,8 @@ class FindResponseStream extends JsonArrayResponseStream {
   }
 
   /** Append the bookmark envelope field and end the response. */
-  async finish(bookmark: string): Promise<void> {
-    await this.closeWith(`],"bookmark":${JSON.stringify(bookmark)}}`);
+  async finish(): Promise<void> {
+    await this.closeWith(`]}`);
   }
 }
 
@@ -146,14 +146,14 @@ export class BulkDocEndpointsController {
 
     const stream = new FindResponseStream(res);
     try {
-      const bookmark = await this.streamPermittedFindDocs(
+      await this.streamPermittedFindDocs(
         db,
         findBody,
         findBody.limit,
         isPermitted,
         stream,
       );
-      await stream.finish(bookmark);
+      await stream.finish();
     } catch (error) {
       if (!res.headersSent) throw error;
       this.logger.warn('aborting streamed _find response after error', {
@@ -174,7 +174,7 @@ export class BulkDocEndpointsController {
     requestedLimit: number,
     isPermitted: (doc: DatabaseDocument) => boolean,
     stream: FindResponseStream,
-  ): Promise<string> {
+  ): Promise<void> {
     let bookmark: string | undefined = body.bookmark;
 
     while (stream.docsWritten < requestedLimit && !stream.isClosed) {
@@ -200,8 +200,6 @@ export class BulkDocEndpointsController {
       if (response.docs.length < internalLimit) break;
       if (!response.bookmark) break;
     }
-
-    return bookmark ?? '';
   }
 
   /**

--- a/src/restricted-endpoints/replication/changes/changes.controller.ts
+++ b/src/restricted-endpoints/replication/changes/changes.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { Response } from 'express';
 import { omit } from 'lodash';
+import { JsonArrayResponseStream } from '../../../common/json-array-response-stream';
 import { firstValueFrom, map } from 'rxjs';
 import { CombinedAuthGuard } from '../../../auth/guards/combined-auth/combined-auth.guard';
 import { User } from '../../../auth/user.decorator';
@@ -32,7 +33,7 @@ import { DocumentFilterService } from '../document-filter/document-filter.servic
  * CouchDB round-trip reduces the number of iterations needed to fill the
  * client's requested limit.
  */
-const INTERNAL_LIMIT_MULTIPLIER = 5;
+export const INTERNAL_LIMIT_MULTIPLIER = 5;
 
 /**
  * Maximum time (ms) to spend iterating through CouchDB changes before
@@ -47,7 +48,7 @@ const MAX_PROCESSING_TIME_MS = 8000;
  * Hard upper cap on the number of changes requested from CouchDB in a single
  * round-trip. Protects the backend from very large client-supplied limits.
  */
-const MAX_INTERNAL_LIMIT = 1000;
+export const MAX_INTERNAL_LIMIT = 1000;
 
 /**
  * Requests taking longer than this are logged as a warning.
@@ -91,36 +92,19 @@ type ChangesProgress = Omit<ChangesSummary, 'resultsWritten'>;
  * everything in memory first (#109). The envelope fields (last_seq, pending,
  * lostPermissions) are appended once the iteration finishes.
  */
-class ChangesResponseStream {
-  private written = 0;
-  private opened = false;
-
+class ChangesResponseStream extends JsonArrayResponseStream {
   constructor(
-    private readonly res: Response,
+    res: Response,
     private readonly includeDocs: boolean,
-  ) {}
-
-  /** number of results written to the response so far */
-  get resultsWritten(): number {
-    return this.written;
-  }
-
-  /** whether the client has disconnected */
-  get isClosed(): boolean {
-    return this.res.destroyed;
+  ) {
+    super(res, '{"results":[');
   }
 
   /** Write one batch of permitted changes, opening the envelope if needed. */
   async writeResults(results: ChangeResult[]): Promise<void> {
-    await this.open();
-    for (const result of results) {
-      const item = this.includeDocs ? result : omit(result, 'doc');
-      await this.writeChunk(
-        (this.written > 0 ? ',' : '') + JSON.stringify(item),
-      );
-      this.written++;
-    }
-    this.flush();
+    await this.writeItems(results, (result) =>
+      this.includeDocs ? result : omit(result, 'doc'),
+    );
   }
 
   /** Append the envelope fields and end the response. */
@@ -129,79 +113,10 @@ class ChangesResponseStream {
     pending: number,
     lostPermissions: string[],
   ): Promise<void> {
-    await this.open();
-    await this.writeChunk(
+    await this.closeWith(
       `],"last_seq":${JSON.stringify(lastSeq)},"pending":${pending}` +
         `,"lostPermissions":${JSON.stringify(lostPermissions)}}`,
     );
-    this.res.end();
-  }
-
-  /**
-   * Send the response headers and open the JSON envelope (idempotent).
-   *
-   * This is deliberately only called after the first CouchDB batch has been
-   * fetched, so that upstream errors (e.g. unknown db) still yield a proper
-   * error status instead of a truncated stream.
-   */
-  private async open(): Promise<void> {
-    if (this.opened) {
-      return;
-    }
-    this.opened = true;
-    this.res.status(200);
-    this.res.setHeader('content-type', 'application/json');
-    await this.writeChunk('{"results":[');
-  }
-
-  /**
-   * Hand the buffered bytes to the client right away.
-   *
-   * Without this the compression middleware keeps a batch in its gzip buffer
-   * until enough data has accumulated, so nothing reaches the client until the
-   * response ends and the incremental writing above has no effect for the
-   * (compressing) clients that actually sync.
-   */
-  private flush() {
-    (this.res as Response & { flush?: () => void }).flush?.();
-  }
-
-  /**
-   * Write a chunk to the response, awaiting the drain event when the
-   * client cannot keep up (backpressure).
-   */
-  private writeChunk(chunk: string): Promise<void> {
-    const res = this.res;
-    return new Promise((resolve, reject) => {
-      if (res.destroyed) {
-        reject(new Error('client disconnected'));
-        return;
-      }
-      if (res.write(chunk)) {
-        resolve();
-        return;
-      }
-      const cleanup = () => {
-        res.off('drain', onDrain);
-        res.off('close', onFailure);
-        res.off('error', onFailure);
-      };
-      const onDrain = () => {
-        cleanup();
-        resolve();
-      };
-      // socket error or close while back-pressured: settle the promise so the
-      // request handler never hangs (which would leak a CouchDB keep-alive
-      // socket). 'error' is required — without it a socket error that does not
-      // also emit 'close' would leave this promise pending forever.
-      const onFailure = () => {
-        cleanup();
-        reject(new Error('client disconnected'));
-      };
-      res.once('drain', onDrain);
-      res.once('close', onFailure);
-      res.once('error', onFailure);
-    });
   }
 }
 
@@ -285,7 +200,7 @@ export class ChangesController {
         db,
         { ...params, since },
         ability,
-        (params?.limit ?? Infinity) - stream.resultsWritten,
+        (params?.limit ?? Infinity) - stream.docsWritten,
       );
       await stream.writeResults(batch.results);
 
@@ -304,7 +219,7 @@ export class ChangesController {
       )
     );
 
-    return { ...progress, resultsWritten: stream.resultsWritten };
+    return { ...progress, resultsWritten: stream.docsWritten };
   }
 
   /**
@@ -318,7 +233,7 @@ export class ChangesController {
     stream: ChangesResponseStream,
   ): boolean {
     const noChangesLeft = pending === 0;
-    const enoughFound = limit !== undefined && stream.resultsWritten >= limit;
+    const enoughFound = limit !== undefined && stream.docsWritten >= limit;
     const outOfTime = Date.now() >= deadline;
     return noChangesLeft || enoughFound || outOfTime || stream.isClosed;
   }


### PR DESCRIPTION
A request on the `_find` endpoint can come with pagination. Similar to the changes feed, the result might be filtered due to permissions. A similar approach to the changes feed is used to reduce the amount of requests needed to provide a full response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added incremental streaming for JSON array responses, allowing large result sets to be delivered progressively.
  * Limited document searches now filter results while maintaining requested limits and continuing across pages when necessary.
  * Changes and document search responses now support improved backpressure and connection handling.

* **Bug Fixes**
  * Improved response completion and error handling when clients disconnect or servers return incomplete result batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->