### PR TITLE
chore(renovate): monitor GitHub Actions and raise security updates immediately

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   ],
   "enabledManagers": ["npm", "dockerfile", "github-actions"],
   "timezone": "Etc/UTC",
-  "schedule": ["after 00:00 and before 09:00 on Monday"],
+  "schedule": ["* * * * 0"],
   "dependencyDashboard": false,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,

--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,19 @@
     "group:allNonMajor",
     ":maintainLockFilesMonthly"
   ],
-  "enabledManagers": ["npm", "dockerfile"],
+  "enabledManagers": ["npm", "dockerfile", "github-actions"],
   "timezone": "Etc/UTC",
   "schedule": ["after 00:00 and before 09:00 on Monday"],
   "dependencyDashboard": false,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "labels": ["dependencies"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"],
+    "labels": ["dependencies", "security"]
+  },
+  "osvVulnerabilityAlerts": true,
   "reviewers": ["sleidig", "Abhinegi2"],
   "rangeStrategy": "bump",
   "constraints": {
@@ -37,6 +43,12 @@
       "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "docker-base-image",
+      "automerge": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions",
       "automerge": false
     }
   ]


### PR DESCRIPTION
Part of a sweep across all six Aam Digital repos to make sure every dependency surface is actually watched by Renovate.

## What was unmonitored

`enabledManagers` is an allowlist and only listed `npm` and `dockerfile`, so the workflow actions were never checked and have drifted: `actions/checkout@v4` (v6 out), `docker/build-push-action@v5` (v7 out), `docker/login-action@v3` (v4 out).

This repo was also missing the `vulnerabilityAlerts` block that ndb-core, aam-services and keycloak-aam already have, so a security fix would have waited for the Monday window like any other update.

## Changes

- `github-actions` added to `enabledManagers`, with minor/patch grouped into a single `github-actions` PR.
- `vulnerabilityAlerts` (schedule `at any time`, `security` label) + `osvVulnerabilityAlerts`, matching the other repos.

## Shared update window

Part of the same sweep: all six repos now use one window — **all day Sunday** (`* * * * 0`). Before this they were split across Monday 00:00–09:00 and Wednesday 00:00–04:00, so update PRs landed on a different day per repo and each window was narrow enough that a hosted-app run could miss it entirely. `vulnerabilityAlerts` still runs at any time, so security fixes are never held to the window.

## Verified

Ran `renovate --platform=local --dry-run` against this branch: github-actions now extracts 3 files / 25 deps. Config passes `renovate-config-validator --strict`.
