### PR TITLE
feat(permissions): managed baseline rules for public form visitors

### DIFF
--- a/src/permissions/rules/default-permissions.spec.ts
+++ b/src/permissions/rules/default-permissions.spec.ts
@@ -1,6 +1,9 @@
+import type { ManagedRulesMerge } from './default-permissions';
 import {
   MANAGED_DEFAULT_RULES,
+  MANAGED_PUBLIC_RULES,
   mergeManagedDefaults,
+  mergeManagedPublic,
   SYSTEM_DEFAULT_MARKER,
 } from './default-permissions';
 import type { DocumentRule } from './rules.service';
@@ -50,5 +53,67 @@ describe('mergeManagedDefaults', () => {
     expect(changed).toBe(true);
     expect(merged).toEqual([...MANAGED_DEFAULT_RULES, adminRule]);
     expect(dropped).toEqual([outdated]);
+  });
+});
+
+describe('mergeManagedPublic', () => {
+  const adminRule: DocumentRule = { action: 'create', subject: 'Child' };
+
+  /** merge an existing section (only a missing section returns undefined) */
+  const mergeSection = (section: DocumentRule[]) =>
+    mergeManagedPublic(section) as ManagedRulesMerge;
+
+  it('should not create a _public section for instances without public forms', () => {
+    expect(mergeManagedPublic(undefined)).toBeUndefined();
+  });
+
+  it('should extend a _public section that is actively used', () => {
+    const result = mergeSection([adminRule]);
+
+    expect(result.changed).toBe(true);
+    expect(result.merged).toEqual([...MANAGED_PUBLIC_RULES, adminRule]);
+  });
+
+  it('should grant read access to the permission config itself', () => {
+    // without this an anonymous client cannot load its own rules and
+    // falls back to allowing everything locally
+    const { merged } = mergeSection([adminRule]);
+
+    expect(
+      merged.some(
+        (rule) =>
+          rule.subject === 'Config' &&
+          rule.action === 'read' &&
+          JSON.stringify(rule.conditions).includes('Config:Permissions'),
+      ),
+    ).toBe(true);
+  });
+
+  it('should report unchanged when the managed rules are already present', () => {
+    const { merged } = mergeSection([adminRule]);
+
+    const second = mergeSection(merged);
+
+    expect(second.changed).toBe(false);
+    expect(second.merged).toEqual(merged);
+    expect(second.dropped).toEqual([]);
+  });
+
+  it('should strip the managed rules again when no admin rule is left', () => {
+    // public forms are no longer used: anonymous visitors must not keep
+    // read access that was only granted to support them
+    const inUse = mergeSection([adminRule]).merged;
+
+    const noLongerUsed = mergeSection(inUse.slice(0, -1));
+
+    expect(noLongerUsed.changed).toBe(true);
+    expect(noLongerUsed.merged).toEqual([]);
+  });
+
+  it('should leave an existing but empty _public section empty', () => {
+    const result = mergeSection([]);
+
+    expect(result.changed).toBe(false);
+    expect(result.merged).toEqual([]);
   });
 });

--- a/src/permissions/rules/default-permissions.spec.ts
+++ b/src/permissions/rules/default-permissions.spec.ts
@@ -60,8 +60,13 @@ describe('mergeManagedPublic', () => {
   const adminRule: DocumentRule = { action: 'create', subject: 'Child' };
 
   /** merge an existing section (only a missing section returns undefined) */
-  const mergeSection = (section: DocumentRule[]) =>
-    mergeManagedPublic(section) as ManagedRulesMerge;
+  function mergeSection(section: DocumentRule[]): ManagedRulesMerge {
+    const result = mergeManagedPublic(section);
+    if (!result) {
+      throw new Error('expected a result for an existing _public section');
+    }
+    return result;
+  }
 
   it('should not create a _public section for instances without public forms', () => {
     expect(mergeManagedPublic(undefined)).toBeUndefined();

--- a/src/permissions/rules/default-permissions.ts
+++ b/src/permissions/rules/default-permissions.ts
@@ -60,22 +60,62 @@ export const MANAGED_DEFAULT_RULES: DocumentRule[] = [
 ];
 
 /**
- * Merge the managed default rules into an existing `default` rules section.
+ * Baseline rules for unauthenticated visitors of a public form.
+ *
+ * `_public` is the `_default` equivalent for anonymous traffic: the `_default`
+ * section is only merged for authenticated accounts (see
+ * `RulesService.getRulesForUser`), so unauthenticated clients need their own
+ * managed baseline.
+ *
+ * Unlike {@link MANAGED_DEFAULT_RULES} these are only written into a `_public`
+ * section that an admin already uses (see {@link mergeManagedPublic}) - an
+ * instance without public forms grants anonymous visitors nothing.
+ */
+export const MANAGED_PUBLIC_RULES: DocumentRule[] = [
+  {
+    // Config:Permissions is what makes the other rules enforceable: a client
+    // that cannot read its own rule set has nothing to enforce and falls back
+    // to allowing everything locally. CONFIG_ENTITY holds the entity/field
+    // definitions a public form is rendered from.
+    action: 'read',
+    subject: 'Config',
+    conditions: {
+      _id: { $in: ['Config:CONFIG_ENTITY', 'Config:Permissions'] },
+    },
+    reason: `${SYSTEM_DEFAULT_MARKER} public form config read access`,
+  },
+  {
+    // branding (logo, colors) of the page the form is displayed on
+    action: 'read',
+    subject: 'SiteSettings',
+    reason: `${SYSTEM_DEFAULT_MARKER} public form site settings read access`,
+  },
+];
+
+/** Outcome of merging a managed rule set into one section of the config. */
+export interface ManagedRulesMerge {
+  merged: DocumentRule[];
+  changed: boolean;
+  dropped: DocumentRule[];
+  /** the section's admin-authored rules, i.e. everything not system-managed */
+  adminRules: DocumentRule[];
+}
+
+/**
+ * Merge a managed rule set into an existing rules section.
  * Managed rules are prepended and any previously written system-default rules
  * are replaced by the current managed set, so updated backend versions
  * refresh their own rules while admin-authored rules stay untouched.
  *
- * A non-array `currentDefault` (e.g. `null` from a malformed document) is
+ * A non-array `currentSection` (e.g. `null` from a malformed document) is
  * treated the same as an empty section instead of throwing, so that a
- * malformed `default` section gets actively healed rather than crashing the
- * caller.
+ * malformed section gets actively healed rather than crashing the caller.
  */
-export function mergeManagedDefaults(currentDefault: DocumentRule[] = []): {
-  merged: DocumentRule[];
-  changed: boolean;
-  dropped: DocumentRule[];
-} {
-  const current = Array.isArray(currentDefault) ? currentDefault : [];
+export function mergeManagedRules(
+  currentSection: DocumentRule[] = [],
+  managedRules: DocumentRule[] = MANAGED_DEFAULT_RULES,
+): ManagedRulesMerge {
+  const current = Array.isArray(currentSection) ? currentSection : [];
   const adminRules = current.filter(
     (rule) =>
       typeof rule.reason !== 'string' ||
@@ -91,8 +131,51 @@ export function mergeManagedDefaults(currentDefault: DocumentRule[] = []): {
   // customized copy of a managed rule. Either way they are dropped here and
   // worth a warning so an admin notices a customization was overwritten.
   const dropped = removedMarkerRules.filter(
-    (rule) => !MANAGED_DEFAULT_RULES.some((managed) => isEqual(managed, rule)),
+    (rule) => !managedRules.some((managed) => isEqual(managed, rule)),
   );
-  const merged = [...MANAGED_DEFAULT_RULES, ...adminRules];
-  return { merged, changed: !isEqual(merged, currentDefault), dropped };
+  const merged = [...managedRules, ...adminRules];
+  return {
+    merged,
+    changed: !isEqual(merged, currentSection),
+    dropped,
+    adminRules,
+  };
+}
+
+/** Merge {@link MANAGED_DEFAULT_RULES} into the `default` rules section. */
+export function mergeManagedDefaults(
+  currentDefault: DocumentRule[] = [],
+): ManagedRulesMerge {
+  return mergeManagedRules(currentDefault, MANAGED_DEFAULT_RULES);
+}
+
+/**
+ * Merge {@link MANAGED_PUBLIC_RULES} into an existing `_public` rules section.
+ *
+ * Only sections that an admin actually uses are extended: the managed rules
+ * are present exactly while the section holds at least one admin-authored
+ * rule. So an instance that does not use public forms is never granted
+ * anonymous read access, and an instance that stops using them has the managed
+ * rules removed again on the next write-back.
+ *
+ * Returns `undefined` when the document has no `_public` section at all - the
+ * section is never created here, only extended.
+ */
+export function mergeManagedPublic(
+  currentPublic: DocumentRule[] | undefined,
+): ManagedRulesMerge | undefined {
+  if (currentPublic === undefined) {
+    return undefined;
+  }
+  const result = mergeManagedRules(currentPublic, MANAGED_PUBLIC_RULES);
+  if (result.adminRules.length > 0) {
+    return result;
+  }
+  // section exists but is unused (empty, or only leftover managed rules):
+  // strip the managed rules again instead of granting anonymous access
+  return {
+    ...result,
+    merged: result.adminRules,
+    changed: !isEqual(result.adminRules, currentPublic),
+  };
 }

--- a/src/permissions/rules/default-permissions.ts
+++ b/src/permissions/rules/default-permissions.ts
@@ -111,7 +111,7 @@ export interface ManagedRulesMerge {
  * treated the same as an empty section instead of throwing, so that a
  * malformed section gets actively healed rather than crashing the caller.
  */
-export function mergeManagedRules(
+function mergeManagedRules(
   currentSection: DocumentRule[] = [],
   managedRules: DocumentRule[] = MANAGED_DEFAULT_RULES,
 ): ManagedRulesMerge {

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -486,82 +486,64 @@ describe('RulesService', () => {
     }
   });
 
-  it('should add the managed public rules to a _public section in use', async () => {
-    jest.useFakeTimers({ doNotFake: ['nextTick'] });
-    try {
+  describe('managed public rules', () => {
+    const publicRule: DocumentRule = { action: 'create', subject: 'Child' };
+
+    beforeEach(() => {
+      jest.useFakeTimers({ doNotFake: ['nextTick'] });
       (mockCouchdbService.put as jest.Mock).mockClear();
-      const publicRule: DocumentRule = { action: 'create', subject: 'Child' };
-      const publicFormDoc = new Permission({
+    });
+
+    afterEach(() => jest.useRealTimers());
+
+    /** let the given doc arrive through the changes feed and run the write-back */
+    async function writeBackFor(data: RulesConfig): Promise<any> {
+      const doc = new Permission(data);
+      doc._rev = '2-abc';
+      jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of(doc));
+
+      changesSubject.next({ id: Permission.DOC_ID, seq: '3' });
+      await new Promise(process.nextTick);
+      jest.advanceTimersByTime(1500);
+
+      return (mockCouchdbService.put as jest.Mock).mock.calls[0]?.[1];
+    }
+
+    it('should add the managed public rules to a _public section in use', async () => {
+      const written = await writeBackFor({
         ...testPermission.data,
         _default: [...MANAGED_DEFAULT_RULES],
         _public: [publicRule],
       });
-      publicFormDoc._rev = '2-abc';
-      jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of(publicFormDoc));
 
-      changesSubject.next({ id: Permission.DOC_ID, seq: '3' });
-      await new Promise(process.nextTick);
-      jest.advanceTimersByTime(1500);
-
-      const written = (mockCouchdbService.put as jest.Mock).mock.calls[0][1];
       expect(written.data._public).toEqual([
         ...MANAGED_PUBLIC_RULES,
         publicRule,
       ]);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
+    });
 
-  it('should not grant anonymous access to instances without public forms', async () => {
-    jest.useFakeTimers({ doNotFake: ['nextTick'] });
-    try {
-      (mockCouchdbService.put as jest.Mock).mockClear();
-      const noPublicFormsDoc = new Permission({
+    it('should not grant anonymous access to instances without public forms', async () => {
+      await writeBackFor({
         ...testPermission.data,
         _default: [...MANAGED_DEFAULT_RULES],
       });
-      noPublicFormsDoc._rev = '2-abc';
-      jest
-        .spyOn(mockCouchdbService, 'get')
-        .mockReturnValue(of(noPublicFormsDoc));
-
-      changesSubject.next({ id: Permission.DOC_ID, seq: '3' });
-      await new Promise(process.nextTick);
-      jest.advanceTimersByTime(1500);
 
       expect(mockCouchdbService.put).not.toHaveBeenCalled();
-    } finally {
-      jest.useRealTimers();
-    }
-  });
+    });
 
-  it('should migrate a legacy public section to the renamed _public key', async () => {
-    jest.useFakeTimers({ doNotFake: ['nextTick'] });
-    try {
-      (mockCouchdbService.put as jest.Mock).mockClear();
-      const publicRule: DocumentRule = { action: 'create', subject: 'Child' };
-      const legacyDoc = new Permission({
+    it('should migrate a legacy public section to the renamed _public key', async () => {
+      const written = await writeBackFor({
         ...testPermission.data,
         _default: [...MANAGED_DEFAULT_RULES],
         public: [publicRule],
       });
-      legacyDoc._rev = '2-abc';
-      jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of(legacyDoc));
 
-      changesSubject.next({ id: Permission.DOC_ID, seq: '3' });
-      await new Promise(process.nextTick);
-      jest.advanceTimersByTime(1500);
-
-      const written = (mockCouchdbService.put as jest.Mock).mock.calls[0][1];
       expect(written.data._public).toEqual([
         ...MANAGED_PUBLIC_RULES,
         publicRule,
       ]);
       expect(written.data.public).toBeUndefined();
-    } finally {
-      jest.useRealTimers();
-    }
+    });
   });
 
   it('should retry with the current doc when the write-back hits a rev conflict', async () => {

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -10,7 +10,10 @@ import {
 } from '../../couchdb/document-changes.service';
 import { UserInfo } from '../../restricted-endpoints/session/user-auth.dto';
 import { UserIdentityService } from '../user-identity/user-identity.service';
-import { MANAGED_DEFAULT_RULES } from './default-permissions';
+import {
+  MANAGED_DEFAULT_RULES,
+  MANAGED_PUBLIC_RULES,
+} from './default-permissions';
 import { Permission, RulesConfig } from './permission';
 import { DocumentRule, RulesService } from './rules.service';
 
@@ -478,6 +481,84 @@ describe('RulesService', () => {
       jest.advanceTimersByTime(1500);
 
       expect(mockCouchdbService.put).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should add the managed public rules to a _public section in use', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+    try {
+      (mockCouchdbService.put as jest.Mock).mockClear();
+      const publicRule: DocumentRule = { action: 'create', subject: 'Child' };
+      const publicFormDoc = new Permission({
+        ...testPermission.data,
+        _default: [...MANAGED_DEFAULT_RULES],
+        _public: [publicRule],
+      });
+      publicFormDoc._rev = '2-abc';
+      jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of(publicFormDoc));
+
+      changesSubject.next({ id: Permission.DOC_ID, seq: '3' });
+      await new Promise(process.nextTick);
+      jest.advanceTimersByTime(1500);
+
+      const written = (mockCouchdbService.put as jest.Mock).mock.calls[0][1];
+      expect(written.data._public).toEqual([
+        ...MANAGED_PUBLIC_RULES,
+        publicRule,
+      ]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should not grant anonymous access to instances without public forms', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+    try {
+      (mockCouchdbService.put as jest.Mock).mockClear();
+      const noPublicFormsDoc = new Permission({
+        ...testPermission.data,
+        _default: [...MANAGED_DEFAULT_RULES],
+      });
+      noPublicFormsDoc._rev = '2-abc';
+      jest
+        .spyOn(mockCouchdbService, 'get')
+        .mockReturnValue(of(noPublicFormsDoc));
+
+      changesSubject.next({ id: Permission.DOC_ID, seq: '3' });
+      await new Promise(process.nextTick);
+      jest.advanceTimersByTime(1500);
+
+      expect(mockCouchdbService.put).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should migrate a legacy public section to the renamed _public key', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+    try {
+      (mockCouchdbService.put as jest.Mock).mockClear();
+      const publicRule: DocumentRule = { action: 'create', subject: 'Child' };
+      const legacyDoc = new Permission({
+        ...testPermission.data,
+        _default: [...MANAGED_DEFAULT_RULES],
+        public: [publicRule],
+      });
+      legacyDoc._rev = '2-abc';
+      jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of(legacyDoc));
+
+      changesSubject.next({ id: Permission.DOC_ID, seq: '3' });
+      await new Promise(process.nextTick);
+      jest.advanceTimersByTime(1500);
+
+      const written = (mockCouchdbService.put as jest.Mock).mock.calls[0][1];
+      expect(written.data._public).toEqual([
+        ...MANAGED_PUBLIC_RULES,
+        publicRule,
+      ]);
+      expect(written.data.public).toBeUndefined();
     } finally {
       jest.useRealTimers();
     }

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -35,8 +35,6 @@ import {
 import {
   ADMIN_APP_ROLE,
   DEFAULT_SECTION_KEY,
-  LEGACY_DEFAULT_KEY,
-  LEGACY_PUBLIC_KEY,
   LEGACY_SECTION_KEYS,
   Permission,
   PUBLIC_SECTION_KEY,
@@ -372,7 +370,7 @@ export class RulesService implements OnModuleInit {
 
   /**
    * Idempotently write the managed system rules into the permission document:
-   * {@link MANAGED_DEFAULT_RULES} into the `default` section (for authenticated
+   * {@link MANAGED_DEFAULT_RULES} into the `_default` section (for authenticated
    * accounts) and {@link MANAGED_PUBLIC_RULES} into the `_public` section, but
    * only where an admin already uses it (see {@link mergeManagedPublic}).
    * Retries on rev conflicts with a freshly fetched doc so that concurrent
@@ -403,10 +401,11 @@ export class RulesService implements OnModuleInit {
   }
 
   /**
-   * One write-back attempt: merge the managed rules into the doc's `default`
-   * and `_public` sections and PUT it if anything changed. Returns "conflict" when the PUT hit a rev
-   * conflict and retrying with a freshly fetched doc makes sense; rethrows
-   * any other error for {@link ensureManagedDefaults} to log.
+   * One write-back attempt: merge the managed rules into the doc's `_default`
+   * and `_public` sections and PUT it if anything changed. Returns "conflict"
+   * when the PUT hit a rev conflict and retrying with a freshly fetched doc
+   * makes sense; rethrows any other error for {@link ensureManagedDefaults} to
+   * log.
    */
   private async writeManagedDefaults(
     db: string,
@@ -416,31 +415,22 @@ export class RulesService implements OnModuleInit {
     if (!PermissionConfigValidator.isValidRulesConfig(doc?.data)) {
       return 'done';
     }
-    const currentDefault =
-      doc.data[DEFAULT_SECTION_KEY] ?? doc.data[LEGACY_DEFAULT_KEY];
-    const hasLegacyDefault = doc.data[LEGACY_DEFAULT_KEY] !== undefined;
-    const defaults = mergeManagedDefaults(currentDefault);
+    // migrating a legacy section key across to the current one is itself a
+    // reason to rewrite, even when no managed rule changed. normalizeSectionKeys
+    // returns the config unchanged when there is nothing to migrate.
+    const data = RulesService.normalizeSectionKeys(doc.data);
+    const hasLegacySectionKeys = data !== doc.data;
 
-    const currentPublic =
-      doc.data[PUBLIC_SECTION_KEY] ?? doc.data[LEGACY_PUBLIC_KEY];
-    const hasLegacyPublic = doc.data[LEGACY_PUBLIC_KEY] !== undefined;
-    const publicRules = mergeManagedPublic(currentPublic);
+    const defaults = mergeManagedDefaults(data[DEFAULT_SECTION_KEY]);
+    const publicRules = mergeManagedPublic(data[PUBLIC_SECTION_KEY]);
 
     const dropped = [...defaults.dropped, ...(publicRules?.dropped ?? [])];
-    // still rewrite when only migrating a legacy key across to the new one
-    if (
-      !defaults.changed &&
-      !hasLegacyDefault &&
-      !publicRules?.changed &&
-      !hasLegacyPublic
-    ) {
+    if (!defaults.changed && !publicRules?.changed && !hasLegacySectionKeys) {
       return 'done';
     }
-    const newData = { ...doc.data, [DEFAULT_SECTION_KEY]: defaults.merged };
-    delete newData[LEGACY_DEFAULT_KEY];
+    const newData = { ...data, [DEFAULT_SECTION_KEY]: defaults.merged };
     if (publicRules) {
       newData[PUBLIC_SECTION_KEY] = publicRules.merged;
-      delete newData[LEGACY_PUBLIC_KEY];
     }
     const updatedDoc: Permission = { ...doc, data: newData };
     this.logger.debug(

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -29,12 +29,14 @@ import { DocumentAbility } from '../permission/permission.service';
 import { UserIdentityService } from '../user-identity/user-identity.service';
 import {
   mergeManagedDefaults,
+  mergeManagedPublic,
   SYSTEM_DEFAULT_MARKER,
 } from './default-permissions';
 import {
   ADMIN_APP_ROLE,
   DEFAULT_SECTION_KEY,
   LEGACY_DEFAULT_KEY,
+  LEGACY_PUBLIC_KEY,
   LEGACY_SECTION_KEYS,
   Permission,
   PUBLIC_SECTION_KEY,
@@ -369,8 +371,10 @@ export class RulesService implements OnModuleInit {
   }
 
   /**
-   * Idempotently write the managed system-default rules into the `default`
-   * section of the permission document (see {@link MANAGED_DEFAULT_RULES}).
+   * Idempotently write the managed system rules into the permission document:
+   * {@link MANAGED_DEFAULT_RULES} into the `default` section (for authenticated
+   * accounts) and {@link MANAGED_PUBLIC_RULES} into the `_public` section, but
+   * only where an admin already uses it (see {@link mergeManagedPublic}).
    * Retries on rev conflicts with a freshly fetched doc so that concurrent
    * admin edits or multiple backend instances converge. Never throws: a
    * failed write-back must not break permission loading, and the next change
@@ -399,8 +403,8 @@ export class RulesService implements OnModuleInit {
   }
 
   /**
-   * One write-back attempt: merge the managed defaults into the doc and PUT
-   * it if anything changed. Returns "conflict" when the PUT hit a rev
+   * One write-back attempt: merge the managed rules into the doc's `default`
+   * and `_public` sections and PUT it if anything changed. Returns "conflict" when the PUT hit a rev
    * conflict and retrying with a freshly fetched doc makes sense; rethrows
    * any other error for {@link ensureManagedDefaults} to log.
    */
@@ -415,13 +419,29 @@ export class RulesService implements OnModuleInit {
     const currentDefault =
       doc.data[DEFAULT_SECTION_KEY] ?? doc.data[LEGACY_DEFAULT_KEY];
     const hasLegacyDefault = doc.data[LEGACY_DEFAULT_KEY] !== undefined;
-    const { merged, changed, dropped } = mergeManagedDefaults(currentDefault);
-    // still rewrite when only migrating the legacy key across to the new one
-    if (!changed && !hasLegacyDefault) {
+    const defaults = mergeManagedDefaults(currentDefault);
+
+    const currentPublic =
+      doc.data[PUBLIC_SECTION_KEY] ?? doc.data[LEGACY_PUBLIC_KEY];
+    const hasLegacyPublic = doc.data[LEGACY_PUBLIC_KEY] !== undefined;
+    const publicRules = mergeManagedPublic(currentPublic);
+
+    const dropped = [...defaults.dropped, ...(publicRules?.dropped ?? [])];
+    // still rewrite when only migrating a legacy key across to the new one
+    if (
+      !defaults.changed &&
+      !hasLegacyDefault &&
+      !publicRules?.changed &&
+      !hasLegacyPublic
+    ) {
       return 'done';
     }
-    const newData = { ...doc.data, [DEFAULT_SECTION_KEY]: merged };
+    const newData = { ...doc.data, [DEFAULT_SECTION_KEY]: defaults.merged };
     delete newData[LEGACY_DEFAULT_KEY];
+    if (publicRules) {
+      newData[PUBLIC_SECTION_KEY] = publicRules.merged;
+      delete newData[LEGACY_PUBLIC_KEY];
+    }
     const updatedDoc: Permission = { ...doc, data: newData };
     this.logger.debug(
       `Writing managed default permissions to "${db}" (rev ${doc._rev ?? 'none'})`,


### PR DESCRIPTION
Anonymous visitors of a public form have no system-managed permission baseline at all.

`RulesService.getRulesForUser()` short-circuits with `if (!user) return this.permission?.[PUBLIC_SECTION_KEY] ?? []`, so `_default` — and with it `MANAGED_DEFAULT_RULES` — never applies to them. Everything an unauthenticated visitor can do is hand-authored per instance.

That matters most for one document, because of a bootstrap recursion: **to know what `_public` allows, the client must first read `Config:Permissions`.** Where an instance doesn't happen to grant that, `DocumentController.getDocument` answers 401 (`UnauthorizedException('unauthorized', 'User is not permitted')` — a rules denial, not an auth failure, since `CombinedAuthGuard` lets anonymous requests through), the frontend cannot load its own rule set, and falls back to allowing everything locally. `CONFIG_ENTITY` and `SiteSettings` are what a public form is rendered from.

### What this adds

`MANAGED_PUBLIC_RULES` — read on `Config:Permissions` + `Config:CONFIG_ENTITY` (scoped by `_id`, like the existing managed rule) and read on `SiteSettings`.

`mergeManagedRules()` generalises the existing merge; `mergeManagedPublic()` applies the policy:

- returns `undefined` when there is no `_public` section — **the section is never created**, only extended, so an instance without public forms is never granted anonymous access;
- adds the managed rules exactly while the section holds at least one admin-authored rule;
- **strips them again** when the last admin rule is removed, so an instance that stops using public forms stops granting the access.

Self-healing in both directions: `ensureManagedDefaults` runs on every change to the permission document, so an instance that later adds its first `_public` rule picks up the baseline on that same write — no migration step.

`writeManagedDefaults` now merges both sections in one write, including the legacy `public` → `_public` key migration the `default` section already had.

### Note on disclosure

This makes the permission document readable by anyone holding a public-form URL on instances that use them: role names, entity types, rule conditions. No user data. It is also *more* precise than the status quo — all `Config` docs share the CASL subject `Config`, so instances that wrote a broad `read: Config` into `_public` already expose it, while this rule is `_id`-scoped.

### Effect on the frontend

The ordinary path then works end to end — `GET /:db` and `GET /:db/_changes` already permit anonymous callers, so the document rules were the only blocker. The `_public` rules get applied client-side, which activates the existing `no_permissions` state in `public-form.component.ts` where the public role lacks create permission, instead of the visitor filling in a form that fails on submit.

Related: Aam-Digital/ndb-core#4315, Aam-Digital/ndb-core#4198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed anonymous-access permissions for public forms, including required configuration and site-settings access.
  * Public permission sections are now automatically enriched and legacy public sections are migrated while preserving custom rules.
  * Permission updates now report removed managed rules and persist changes across applicable sections.

* **Bug Fixes**
  * Prevented unnecessary creation or updates of public permission sections when no public form exists.
  * Preserved explicitly empty sections and administrator-defined permissions during rule updates.

* **Tests**
  * Expanded coverage for permission merging, migration, idempotence, and write-back behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->