### PR TITLE
fix: wrong pagination with `_find` endpoint with permissions

### DIFF
--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
@@ -167,7 +167,7 @@ describe('BulkDocEndpointsController', () => {
     expect(mockCouchDBService.post).toHaveBeenCalledWith(
       'db',
       '_find',
-      expect.objectContaining({ limit: 125 }), // 10 * INTERNAL_LIMIT_MULTIPLIER
+      expect.objectContaining({ limit: 125 }), // Default limit (25) * INTERNAL_LIMIT_MULTIPLIER
     );
     expect(mockCouchDBService.post).not.toHaveBeenCalledWith(
       expect.anything(),

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
@@ -150,31 +150,7 @@ describe('BulkDocEndpointsController', () => {
     expect(body().rows).toEqual([{ id: 'x' }]);
   });
 
-  it('should stream and filter the _find response per doc', async () => {
-    const findResponse = {
-      docs: [{ _id: 'Report:1' }, { _id: 'Secret:1' }],
-      bookmark: 'abc',
-    };
-    jest
-      .spyOn(mockCouchDBService, 'postStream')
-      .mockResolvedValue(asStream(findResponse));
-    jest
-      .spyOn(documentFilter, 'findDocFilter')
-      .mockReturnValue((doc) => doc._id === 'Report:1');
-    const { res, body } = createMockResponse();
-
-    const request = { selector: { type: 'report' } };
-    await controller.find('db', request, user, res);
-
-    expect(mockCouchDBService.postStream).toHaveBeenCalledWith(
-      'db',
-      '_find',
-      request,
-    );
-    expect(body()).toEqual({ docs: [{ _id: 'Report:1' }], bookmark: 'abc' });
-  });
-
-  it('should use the buffered path, omit skip and filter docs when _find body has a limit', async () => {
+  it('should filter docs based on permissions on _find', async () => {
     jest.spyOn(mockCouchDBService, 'post').mockReturnValue(
       of({
         docs: [{ _id: 'Report:1' }, { _id: 'Secret:1' }],
@@ -186,12 +162,12 @@ describe('BulkDocEndpointsController', () => {
       .mockReturnValue((doc) => doc._id === 'Report:1');
     const { res, body } = createMockResponse();
 
-    await controller.find('db', { selector: {}, limit: 10 }, user, res);
+    await controller.find('db', { selector: {} }, user, res);
 
     expect(mockCouchDBService.post).toHaveBeenCalledWith(
       'db',
       '_find',
-      expect.objectContaining({ limit: 50 }), // 10 * INTERNAL_LIMIT_MULTIPLIER
+      expect.objectContaining({ limit: 125 }), // 10 * INTERNAL_LIMIT_MULTIPLIER
     );
     expect(mockCouchDBService.post).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -199,7 +175,6 @@ describe('BulkDocEndpointsController', () => {
       expect.objectContaining({ skip: expect.anything() }),
     );
     expect(body()).toEqual({ docs: [{ _id: 'Report:1' }], bookmark: 'bm1' });
-    
   });
 
   it('should iterate _find with bookmark when filtered results are below the limit', async () => {

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.spec.ts
@@ -174,7 +174,7 @@ describe('BulkDocEndpointsController', () => {
     expect(body()).toEqual({ docs: [{ _id: 'Report:1' }], bookmark: 'abc' });
   });
 
-  it('should use the buffered path and filter docs when _find body has a limit', async () => {
+  it('should use the buffered path, omit skip and filter docs when _find body has a limit', async () => {
     jest.spyOn(mockCouchDBService, 'post').mockReturnValue(
       of({
         docs: [{ _id: 'Report:1' }, { _id: 'Secret:1' }],
@@ -191,9 +191,15 @@ describe('BulkDocEndpointsController', () => {
     expect(mockCouchDBService.post).toHaveBeenCalledWith(
       'db',
       '_find',
-      expect.objectContaining({ limit: 50 }), // 10 * FIND_LIMIT_MULTIPLIER
+      expect.objectContaining({ limit: 50 }), // 10 * INTERNAL_LIMIT_MULTIPLIER
     );
-    expect(body()).toEqual({ docs: [{ _id: 'Report:1' }] });
+    expect(mockCouchDBService.post).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ skip: expect.anything() }),
+    );
+    expect(body()).toEqual({ docs: [{ _id: 'Report:1' }], bookmark: 'bm1' });
+    
   });
 
   it('should iterate _find with bookmark when filtered results are below the limit', async () => {
@@ -228,6 +234,7 @@ describe('BulkDocEndpointsController', () => {
     );
     const result = body();
     expect(result.docs).toHaveLength(5);
+    expect(result.bookmark).toBe('bm2');
   });
 
   it('should stop iterating _find when CouchDB returns fewer docs than requested', async () => {
@@ -241,7 +248,56 @@ describe('BulkDocEndpointsController', () => {
 
     // Only one call — CouchDB returned 1 < 50 (internal limit), so no more pages
     expect(mockCouchDBService.post).toHaveBeenCalledTimes(1);
-    expect(body()).toEqual({ docs: [] });
+    expect(body()).toEqual({ docs: [], bookmark: 'bm1' });
+  });
+
+  it('should re-fetch with exact limit when a batch has more permitted docs than needed', async () => {
+    // limit=2, internalLimit=10, batch has [P0, F1, P2, F3, P4, F5, P6, F7, P8, F9]
+    // allPermitted=[P0,P2,P4,P6,P8], remaining=2 → overflow
+    // lastNeededRawIndex = index of P2 = 2 → re-fetch with limit=3
+    // re-fetch returns [P0,F1,P2], bookmark='exact-bm'
+    const overflowBatch = {
+      docs: [
+        { _id: 'P:0' },
+        { _id: 'F:1' },
+        { _id: 'P:2' },
+        { _id: 'F:3' },
+        { _id: 'P:4' },
+        { _id: 'F:5' },
+        { _id: 'P:6' },
+        { _id: 'F:7' },
+        { _id: 'P:8' },
+        { _id: 'F:9' },
+      ],
+      bookmark: 'wide-bm',
+    };
+    const exactBatch = {
+      docs: [{ _id: 'P:0' }, { _id: 'F:1' }, { _id: 'P:2' }],
+      bookmark: 'exact-bm',
+    };
+    jest
+      .spyOn(mockCouchDBService, 'post')
+      .mockReturnValueOnce(of(overflowBatch))
+      .mockReturnValueOnce(of(exactBatch));
+    jest
+      .spyOn(documentFilter, 'findDocFilter')
+      .mockReturnValue((doc) => !!doc._id?.startsWith('P'));
+    const { res, body } = createMockResponse();
+
+    await controller.find('db', { selector: {}, limit: 2 }, user, res);
+
+    // Second call must use the exact limit (index 2 + 1 = 3)
+    expect(mockCouchDBService.post).toHaveBeenCalledTimes(2);
+    expect(mockCouchDBService.post).toHaveBeenNthCalledWith(
+      2,
+      'db',
+      '_find',
+      expect.objectContaining({ limit: 3, bookmark: undefined }),
+    );
+    const result = body();
+    expect(result.docs).toEqual([{ _id: 'P:0' }, { _id: 'P:2' }]);
+    // bookmark comes from the exact re-fetch, not the wide batch
+    expect(result.bookmark).toBe('exact-bm');
   });
 
   it('should abort the response if the upstream stream fails mid-transfer', async () => {

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
@@ -168,11 +168,7 @@ export class BulkDocEndpointsController {
    */
   private async streamPermittedFindDocs(
     db: string,
-    body: {
-      limit?: number;
-      bookmark?: string;
-      [key: string]: unknown;
-    },
+    body: { bookmark?: string; [key: string]: unknown },
     requestedLimit: number,
     isPermitted: (doc: DatabaseDocument) => boolean,
     stream: FindResponseStream,

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
@@ -113,6 +113,8 @@ export class BulkDocEndpointsController {
    * Find documents using a declarative JSON querying syntax.
    * The response is permission-filtered and streamed.
    * See {@link https://docs.couchdb.org/en/stable/api/database/find.html#post--db-_find}
+   * If `body.limit` is undefined, 25 is used (same as CouchDB).
+   * `body.skip` is discarded, only `body.bookmark` is supported.
    *
    * @param db name of the database to query
    * @param body search query object
@@ -125,30 +127,26 @@ export class BulkDocEndpointsController {
   })
   async find(
     @Param('db') db: string,
-    @Body() body: object,
+    @Body()
+    body: {
+      limit?: number;
+      skip?: number;
+      bookmark?: string;
+      [key: string]: unknown;
+    },
     @User() user: UserInfo,
     @Res() res: Response,
   ): Promise<void> {
     const isPermitted = this.bulkDocumentService.findDocFilter(user);
-    const findBody = body as { limit?: number; [key: string]: unknown };
-
-    if (findBody.limit === undefined) {
-      const source = await this.couchdbService.postStream(db, '_find', body);
-      await this.streamFiltered(
-        source,
-        'docs',
-        (doc) => (isPermitted(doc) ? doc : undefined),
-        res,
-      );
-      return;
-    }
+    body.limit = body.limit ?? 25;
+    delete body.skip;
 
     const stream = new FindResponseStream(res);
     try {
       const bookmark = await this.streamPermittedFindDocs(
         db,
-        findBody,
-        findBody.limit,
+        body,
+        body.limit,
         isPermitted,
         stream,
       );
@@ -167,31 +165,19 @@ export class BulkDocEndpointsController {
    * and stream each permitted batch to the client. Uses the CouchDB `bookmark`
    * to continue between rounds. Returns the bookmark that the client should use
    * for the next page.
-   *
-   * `skip` is intentionally stripped from the body: CouchDB's `skip` is a
-   * raw-document offset and would overlap with documents already returned when
-   * the backend makes multiple internal fetches. Clients should use the returned
-   * `bookmark` for subsequent pages instead.
-   *
-   * When the last internal batch contains more permitted docs than needed, a
-   * second targeted fetch is made with an exact limit so that the returned
-   * bookmark points precisely to after the last doc written to the client —
-   * preventing those docs from being silently skipped on the next page.
    */
   private async streamPermittedFindDocs(
     db: string,
     body: {
       limit?: number;
       bookmark?: string;
-      skip?: unknown;
       [key: string]: unknown;
     },
     requestedLimit: number,
     isPermitted: (doc: DatabaseDocument) => boolean,
     stream: FindResponseStream,
   ): Promise<string> {
-    const { skip: _skip, ...findBody } = body;
-    let bookmark: string | undefined = findBody.bookmark;
+    let bookmark = body.bookmark;
 
     while (stream.docsWritten < requestedLimit && !stream.isClosed) {
       const remaining = requestedLimit - stream.docsWritten;
@@ -203,7 +189,7 @@ export class BulkDocEndpointsController {
       const batchStartBookmark = bookmark;
       const response = await firstValueFrom(
         this.couchdbService.post<FindResponse>(db, '_find', {
-          ...findBody,
+          ...body,
           limit: internalLimit,
           bookmark,
         }),
@@ -221,7 +207,7 @@ export class BulkDocEndpointsController {
         );
         const exact = await firstValueFrom(
           this.couchdbService.post<FindResponse>(db, '_find', {
-            ...findBody,
+            ...body,
             limit: lastNeededRawIndex + 1,
             bookmark: batchStartBookmark,
           }),

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
@@ -180,7 +180,12 @@ export class BulkDocEndpointsController {
    */
   private async streamPermittedFindDocs(
     db: string,
-    body: { limit?: number; bookmark?: string; skip?: unknown; [key: string]: unknown },
+    body: {
+      limit?: number;
+      bookmark?: string;
+      skip?: unknown;
+      [key: string]: unknown;
+    },
     requestedLimit: number,
     isPermitted: (doc: DatabaseDocument) => boolean,
     stream: FindResponseStream,
@@ -221,7 +226,9 @@ export class BulkDocEndpointsController {
             bookmark: batchStartBookmark,
           }),
         );
-        await stream.writeDocs(exact.docs.filter(isPermitted).slice(0, remaining));
+        await stream.writeDocs(
+          exact.docs.filter(isPermitted).slice(0, remaining),
+        );
         bookmark = exact.bookmark;
         break;
       }

--- a/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
+++ b/src/restricted-endpoints/replication/bulk-document/bulk-doc-endpoints.controller.ts
@@ -58,9 +58,9 @@ class FindResponseStream extends JsonArrayResponseStream {
     await this.writeItems(docs, (doc) => doc);
   }
 
-  /** End the response. */
-  async finish(): Promise<void> {
-    await this.closeWith(`]}`);
+  /** Append the bookmark and end the response. */
+  async finish(bookmark: string): Promise<void> {
+    await this.closeWith(`],"bookmark":${JSON.stringify(bookmark)}}`);
   }
 }
 
@@ -145,14 +145,14 @@ export class BulkDocEndpointsController {
 
     const stream = new FindResponseStream(res);
     try {
-      await this.streamPermittedFindDocs(
+      const bookmark = await this.streamPermittedFindDocs(
         db,
         findBody,
         findBody.limit,
         isPermitted,
         stream,
       );
-      await stream.finish();
+      await stream.finish(bookmark);
     } catch (error) {
       if (!res.headersSent) throw error;
       this.logger.warn('aborting streamed _find response after error', {
@@ -165,16 +165,28 @@ export class BulkDocEndpointsController {
   /**
    * Iteratively fetch from `_find` with an inflated limit, filter by permission,
    * and stream each permitted batch to the client. Uses the CouchDB `bookmark`
-   * to continue between rounds.
+   * to continue between rounds. Returns the bookmark that the client should use
+   * for the next page.
+   *
+   * `skip` is intentionally stripped from the body: CouchDB's `skip` is a
+   * raw-document offset and would overlap with documents already returned when
+   * the backend makes multiple internal fetches. Clients should use the returned
+   * `bookmark` for subsequent pages instead.
+   *
+   * When the last internal batch contains more permitted docs than needed, a
+   * second targeted fetch is made with an exact limit so that the returned
+   * bookmark points precisely to after the last doc written to the client —
+   * preventing those docs from being silently skipped on the next page.
    */
   private async streamPermittedFindDocs(
     db: string,
-    body: { limit?: number; bookmark?: string; [key: string]: unknown },
+    body: { limit?: number; bookmark?: string; skip?: unknown; [key: string]: unknown },
     requestedLimit: number,
     isPermitted: (doc: DatabaseDocument) => boolean,
     stream: FindResponseStream,
-  ): Promise<void> {
-    let bookmark: string | undefined = body.bookmark;
+  ): Promise<string> {
+    const { skip: _skip, ...findBody } = body;
+    let bookmark: string | undefined = findBody.bookmark;
 
     while (stream.docsWritten < requestedLimit && !stream.isClosed) {
       const remaining = requestedLimit - stream.docsWritten;
@@ -183,22 +195,45 @@ export class BulkDocEndpointsController {
         MAX_INTERNAL_LIMIT,
       );
 
+      const batchStartBookmark = bookmark;
       const response = await firstValueFrom(
         this.couchdbService.post<FindResponse>(db, '_find', {
-          ...body,
+          ...findBody,
           limit: internalLimit,
           bookmark,
         }),
       );
 
-      const permitted = response.docs.filter(isPermitted).slice(0, remaining);
-      await stream.writeDocs(permitted);
+      const allPermitted = response.docs.filter(isPermitted);
 
+      if (allPermitted.length > remaining) {
+        // The batch has more permitted docs than needed. Re-fetch with a limit
+        // sized to include exactly the docs we will return, so the resulting
+        // bookmark points to just after the last written doc rather than past
+        // the dropped permitted docs.
+        const lastNeededRawIndex = response.docs.indexOf(
+          allPermitted[remaining - 1],
+        );
+        const exact = await firstValueFrom(
+          this.couchdbService.post<FindResponse>(db, '_find', {
+            ...findBody,
+            limit: lastNeededRawIndex + 1,
+            bookmark: batchStartBookmark,
+          }),
+        );
+        await stream.writeDocs(exact.docs.filter(isPermitted).slice(0, remaining));
+        bookmark = exact.bookmark;
+        break;
+      }
+
+      await stream.writeDocs(allPermitted);
       bookmark = response.bookmark;
 
       if (response.docs.length < internalLimit) break;
       if (!response.bookmark) break;
     }
+
+    return bookmark ?? '';
   }
 
   /**


### PR DESCRIPTION
Currently, the `_find` endpoint might create invalid pages when using the `_find` endpoint and permissions enabled. This is because the skip of the request does not necessarily correspondent to the skip needed on the server. Instead the bookmark functionality is used and forwarded. Skip is ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination for streamed document searches by returning a bookmark for subsequent requests.
  * Prevented documents from being skipped when filtering results across pages.
  * Ensured pagination requests use the correct result limits and ignore unsupported skip values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->