### PR TITLE
chore: group node updates from Dockerfile and github-actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,12 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "github-actions",
       "automerge": false
+    },
+    {
+      "matchManagers": ["dockerfile", "github-actions"],
+      "matchPackageNames": ["node"],
+      "groupName": "node",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a Renovate `packageRule` that groups `node` updates across the `dockerfile` and `github-actions` managers into a single `node` group, so a Node.js version bump no longer opens two separate PRs (one for the Dockerfile base image, one for the `actions/setup-node` `node-version` input), as happened with #335 and #336.

## Test plan
- [x] Validated with `renovate-config-validator`
- [ ] Confirm the next Node.js release produces a single combined PR