### PR TITLE
chore: remove the legacy permission section keys

### DIFF
--- a/src/permissions/rules/permission.ts
+++ b/src/permissions/rules/permission.ts
@@ -7,54 +7,32 @@ export const ADMIN_APP_ROLE = 'admin_app';
 /**
  * Section keys in {@link RulesConfig} that carry special semantics instead of
  * mapping a user role. The underscore prefix marks them as internal so they
- * cannot collide with a realm role name. Legacy (non-prefixed) spellings are
- * still read for backward compatibility until all documents are migrated.
+ * cannot collide with a realm role name.
  */
 export const DEFAULT_SECTION_KEY = '_default';
 export const PUBLIC_SECTION_KEY = '_public';
-/** @deprecated use {@link DEFAULT_SECTION_KEY}; only read for migration */
-export const LEGACY_DEFAULT_KEY = 'default';
-/** @deprecated use {@link PUBLIC_SECTION_KEY}; only read for migration */
-export const LEGACY_PUBLIC_KEY = 'public';
-
-/**
- * Legacy section key -> current section key. A config that still uses a legacy
- * key is normalized onto the current one when it is loaded, so only migration
- * code needs to know about the old spellings.
- *
- * @deprecated remove together with the legacy keys in the next major version
- */
-export const LEGACY_SECTION_KEYS: Record<string, string> = {
-  [LEGACY_DEFAULT_KEY]: DEFAULT_SECTION_KEY,
-  [LEGACY_PUBLIC_KEY]: PUBLIC_SECTION_KEY,
-};
 
 /** A user role starting with this prefix is reserved and never resolved. */
 export const RESERVED_ROLE_PREFIX = '_';
 
 /**
- * All section keys (current and legacy) that must never be resolved as if they
- * were user role names, even if a realm role with the same name exists.
+ * All section keys that must never be resolved as if they were user role names,
+ * even if a realm role with the same name exists.
  */
 export const RESERVED_RULE_CONFIG_KEYS: string[] = [
   DEFAULT_SECTION_KEY,
   PUBLIC_SECTION_KEY,
-  ...Object.keys(LEGACY_SECTION_KEYS),
 ];
 
 /**
  * The format of the JSON object which defines the rules for each role.
  * The format is `<user-role>: <array of DocumentRule>`, meaning for each role an array of rules can be defined.
- * The rules defined in '_default' (legacy 'default') are prepended to any other rules defined for a user.
- * The rules defined in '_public' (legacy 'public') are used if a user is not logged in.
+ * The rules defined in '_default' are prepended to any other rules defined for a user.
+ * The rules defined in '_public' are used if a user is not logged in.
  */
 export type RulesConfig = {
   _public?: DocumentRule[];
   _default?: DocumentRule[];
-  /** @deprecated use {@link RulesConfig._public} */
-  public?: DocumentRule[];
-  /** @deprecated use {@link RulesConfig._default} */
-  default?: DocumentRule[];
   [key: string]: DocumentRule[] | undefined;
 };
 

--- a/src/permissions/rules/rules.service.spec.ts
+++ b/src/permissions/rules/rules.service.spec.ts
@@ -180,26 +180,6 @@ describe('RulesService', () => {
     ]);
   });
 
-  it('should normalize a not-yet-migrated legacy default/public section on load', () => {
-    const defaultRule: DocumentRule = { subject: 'Config', action: 'read' };
-    const publicRule: DocumentRule = {
-      subject: 'SiteSettings',
-      action: 'read',
-    };
-    loadPermissionConfig({
-      ...testPermission.data,
-      default: [defaultRule],
-      public: [publicRule],
-    });
-
-    expect(service.getRulesForUser(normalUser)).toEqual(
-      [defaultRule].concat(userRules),
-    );
-    expect(service.getRulesForUser(undefined as unknown as UserInfo)).toEqual([
-      publicRule,
-    ]);
-  });
-
   it('should prefer the renamed section key when a config still carries both', () => {
     const newRule: DocumentRule = { subject: 'Config', action: 'read' };
     const newPublicRule: DocumentRule = {
@@ -367,18 +347,6 @@ describe('RulesService', () => {
     jest.useRealTimers();
   });
 
-  it('should not emit permissionsChanged when a legacy section key is migrated to its new name', () => {
-    const rule: DocumentRule = { subject: 'Config', action: 'read' };
-    loadPermissionConfig({ ...testPermission.data, default: [rule] });
-    const changed = jest.fn();
-    service.permissionsChanged$.subscribe(changed);
-
-    // identical rules, only stored under the renamed section key
-    loadPermissionConfig({ ...testPermission.data, _default: [rule] });
-
-    expect(changed).not.toHaveBeenCalled();
-  });
-
   it('should restore managed defaults when a change strips them', async () => {
     jest.useFakeTimers({ doNotFake: ['nextTick'] });
     try {
@@ -386,7 +354,7 @@ describe('RulesService', () => {
       const adminRule: DocumentRule = { action: 'read', subject: 'Child' };
       const strippedDoc = new Permission({
         ...testPermission.data,
-        default: [adminRule],
+        _default: [adminRule],
       });
       strippedDoc._rev = '2-abc';
       jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of(strippedDoc));
@@ -433,33 +401,6 @@ describe('RulesService', () => {
           }),
         }),
       );
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('should migrate a legacy default section to the renamed _default key', async () => {
-    jest.useFakeTimers({ doNotFake: ['nextTick'] });
-    try {
-      (mockCouchdbService.put as jest.Mock).mockClear();
-      const adminRule: DocumentRule = { action: 'read', subject: 'Child' };
-      const legacyDoc = new Permission({
-        ...testPermission.data,
-        default: [...MANAGED_DEFAULT_RULES, adminRule],
-      });
-      legacyDoc._rev = '2-abc';
-      jest.spyOn(mockCouchdbService, 'get').mockReturnValue(of(legacyDoc));
-
-      changesSubject.next({ id: Permission.DOC_ID, seq: '3' });
-      await new Promise(process.nextTick);
-      jest.advanceTimersByTime(1500);
-
-      const written = (mockCouchdbService.put as jest.Mock).mock.calls[0][1];
-      expect(written.data._default).toEqual([
-        ...MANAGED_DEFAULT_RULES,
-        adminRule,
-      ]);
-      expect(written.data.default).toBeUndefined();
     } finally {
       jest.useRealTimers();
     }
@@ -529,20 +470,6 @@ describe('RulesService', () => {
       });
 
       expect(mockCouchdbService.put).not.toHaveBeenCalled();
-    });
-
-    it('should migrate a legacy public section to the renamed _public key', async () => {
-      const written = await writeBackFor({
-        ...testPermission.data,
-        _default: [...MANAGED_DEFAULT_RULES],
-        public: [publicRule],
-      });
-
-      expect(written.data._public).toEqual([
-        ...MANAGED_PUBLIC_RULES,
-        publicRule,
-      ]);
-      expect(written.data.public).toBeUndefined();
     });
   });
 

--- a/src/permissions/rules/rules.service.ts
+++ b/src/permissions/rules/rules.service.ts
@@ -35,7 +35,6 @@ import {
 import {
   ADMIN_APP_ROLE,
   DEFAULT_SECTION_KEY,
-  LEGACY_SECTION_KEYS,
   Permission,
   PUBLIC_SECTION_KEY,
   RESERVED_ROLE_PREFIX,
@@ -92,34 +91,9 @@ export class RulesService implements OnModuleInit {
    */
   readonly permissionsChanged$ = this.permissionsChanged.asObservable();
 
-  /**
-   * Single write point for the in-memory config. Legacy section keys are
-   * normalized onto their current spelling here, so every read path only has to
-   * know about {@link DEFAULT_SECTION_KEY} and {@link PUBLIC_SECTION_KEY}.
-   */
+  /** Single write point for the in-memory config. */
   private setPermission(config: RulesConfig): void {
-    this.permission = RulesService.normalizeSectionKeys(config);
-  }
-
-  /**
-   * Move rules stored under a legacy section key onto the current key. The
-   * current key wins if a config carries both, matching the write-back in
-   * {@link writeManagedDefaults} that drops the legacy one.
-   */
-  private static normalizeSectionKeys(config: RulesConfig): RulesConfig {
-    const legacyKeys = Object.keys(LEGACY_SECTION_KEYS).filter(
-      (key) => config[key] !== undefined,
-    );
-    if (legacyKeys.length === 0) {
-      return config;
-    }
-    const normalized = { ...config };
-    for (const legacyKey of legacyKeys) {
-      const currentKey = LEGACY_SECTION_KEYS[legacyKey];
-      normalized[currentKey] = normalized[currentKey] ?? normalized[legacyKey];
-      delete normalized[legacyKey];
-    }
-    return normalized;
+    this.permission = config;
   }
 
   constructor(
@@ -308,8 +282,6 @@ export class RulesService implements OnModuleInit {
     }
 
     this.setPermission(newPermissions);
-    // compare the normalized configs: migrating a legacy section key is not a
-    // rule change and must not trigger a cache clear / client re-sync
     this.onPermissionsChanged(db, prevPermissions, this.permission);
     void this.ensureManagedDefaults(db, permissionDoc);
   }
@@ -415,17 +387,13 @@ export class RulesService implements OnModuleInit {
     if (!PermissionConfigValidator.isValidRulesConfig(doc?.data)) {
       return 'done';
     }
-    // migrating a legacy section key across to the current one is itself a
-    // reason to rewrite, even when no managed rule changed. normalizeSectionKeys
-    // returns the config unchanged when there is nothing to migrate.
-    const data = RulesService.normalizeSectionKeys(doc.data);
-    const hasLegacySectionKeys = data !== doc.data;
+    const data = doc.data;
 
     const defaults = mergeManagedDefaults(data[DEFAULT_SECTION_KEY]);
     const publicRules = mergeManagedPublic(data[PUBLIC_SECTION_KEY]);
 
     const dropped = [...defaults.dropped, ...(publicRules?.dropped ?? [])];
-    if (!defaults.changed && !publicRules?.changed && !hasLegacySectionKeys) {
+    if (!defaults.changed && !publicRules?.changed) {
       return 'done';
     }
     const newData = { ...data, [DEFAULT_SECTION_KEY]: defaults.merged };
@@ -485,8 +453,7 @@ export class RulesService implements OnModuleInit {
       const userRules = user.roles
         .filter(
           // reserved section keys and any underscore-prefixed name carry
-          // special semantics and never resolve as a user role; legacy keys are
-          // already normalized away, they are listed to keep the guard explicit
+          // special semantics and never resolve as a user role
           (role) =>
             !role.startsWith(RESERVED_ROLE_PREFIX) &&
             !RESERVED_RULE_CONFIG_KEYS.includes(role) &&

--- a/test/utils/test-app.ts
+++ b/test/utils/test-app.ts
@@ -13,7 +13,7 @@ import { MockCouchDb } from './mock-couchdb';
  * - anonymous (public): read Aggregate
  */
 export const DEFAULT_TEST_RULES = {
-  public: [{ action: 'read', subject: 'Aggregate' }],
+  _public: [{ action: 'read', subject: 'Aggregate' }],
   admin_app: [{ action: 'manage', subject: 'all' }],
   user_app: [
     { action: 'read', subject: 'Child' },


### PR DESCRIPTION
- closes #295

Part of #295 (backend half). The ndb-core half is in Aam-Digital/ndb-core#4354.

The reserved sections of `Config:Permissions` were renamed `default` -> `_default` and `public` -> `_public`. The non-prefixed spellings stayed readable only so code could ship before every document had been migrated. All instances now have `_default` / `_public` in their CouchDB, so the compatibility layer can go.

## Removed

- `LEGACY_DEFAULT_KEY`, `LEGACY_PUBLIC_KEY` and `LEGACY_SECTION_KEYS` in `src/permissions/rules/permission.ts`
- the deprecated `public` / `default` members of `RulesConfig`, and their entries in `RESERVED_RULE_CONFIG_KEYS`
- `RulesService.normalizeSectionKeys` and its call in `setPermission`
- the legacy branch of `RulesService.writeManagedDefaults` — it now reads `_default` / `_public` only, and no longer rewrites a document just to migrate a section key

Behaviour for an already-migrated document is unchanged; only the migration path is gone.

## Precondition

**An instance that has not run the key-rename migration loses its shared `default` / `public` rules with this change** — they are simply no longer read. Both one-off migrations (`oneoff-20260724-permissions-key-rename`, then `oneoff-20260804-permissions-key-legacy-cleanup`) must have run everywhere before this is merged.

Draft until that is confirmed, and until the matching ndb-core PR is ready — the two should be released together so no deployed frontend is left reading a spelling the backend no longer writes.

## Testing

- `npm test` — 290 passed, 32 suites
- `npm run build` — clean

Tests that only covered the legacy-to-current migration were removed; the ones that used `default:` / `public:` merely as a key name now use the prefixed spelling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for legacy `default` and `public` permission section keys.
  * Permission configurations must use the current `_default` and `_public` section keys.
  * Legacy section-key migration and automatic normalization are no longer performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->